### PR TITLE
move project to virt-s1

### DIFF
--- a/.github/workflows/notify_gchat.yml
+++ b/.github/workflows/notify_gchat.yml
@@ -1,0 +1,16 @@
+# https://github.com/marketplace/actions/google-chat-github-notification
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
+name: notify gchat os-tests
+on:
+  pull_request:
+    types: [opened, reopened, closed]
+  pull_request_review_comment:
+    types: [created]
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Google Chat Notification
+      uses: CommonMarvel/google-chat-notification@v1.1.1
+      with:
+        url: ${{ secrets.GOOGLE_CHAT_WEBHOOK_OS_TESTS }}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There is an pynacl issue when installing paramiko-fork on RHEL-8.6. Please insta
 ### Install from source code
 
 ```bash
-# git clone https://github.com/liangxiao1/os-tests.git
+# git clone https://github.com/virt-s1/os-tests.git
 # cd os-tests
 # python3 setup.py install
 ```

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     description="Lightweight, portable and customer centric tests collection for Linux OS",
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
-    url="https://github.com/liangxiao1/os-tests",
+    url="https://github.com/virt-s1/os-tests",
     #packages=setuptools.find_packages(),
     packages=[ 'os_tests', 'os_tests.tests', 'os_tests.libs'],
     package_data={
@@ -22,7 +22,7 @@ setuptools.setup(
     },
     include_package_data=True,
     #data_files=[('/'+os.path.expanduser("~"), ['cfg/os-tests.yaml']),],
-    install_requires=['PyYAML', 'Jinja2<=2.11.3', 'tipset>=0.0.15'],
+    install_requires=['PyYAML', 'Jinja2<=2.11.3', 'tipset>=0.0.15', 'markupsafe<=1.1.1'],
     license="GPLv3+",
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',


### PR DESCRIPTION
2 more changes:
- specify markupsafe version to 1.1.1 because 2.1.0 dropped soft_unicode that jinjia2 used.
  upgrade both jinjia2 and markupsafe to the latest also works, but rhel9.0 has 1.1.1 by default.
- add a action job to notify gchat os-tests space

Signed-off-by: Xiao Liang <xiliang@redhat.com>