### PR TITLE
Do not use qemu64 since rhel9 doesn't support it

### DIFF
--- a/os_tests/libs/resources_libvirt.py
+++ b/os_tests/libs/resources_libvirt.py
@@ -236,6 +236,7 @@ dom_xml = """
     <acpi/>
     <apic/>
   </features>
+  <cpu mode='host-model' check='partial'/>
   <devices>
     <emulator>/usr/libexec/qemu-kvm</emulator>
     <disk type='file' device='disk'>


### PR DESCRIPTION
This is a bug fix

Signed-off-by: Wei Shi <wshi@redhat.com>