### PR TITLE
Fix KeyError: 'remote_node' issue

### DIFF
--- a/os_tests/tests/test_general_check.py
+++ b/os_tests/tests/test_general_check.py
@@ -2030,7 +2030,7 @@ current_device"
                 msg="please attach this archive if file bug", timeout=180)
         gz_file = re.findall('/var/.*tar.gz', out)[0]
         file_name = gz_file.split('/')[-1]
-        if self.params['remote_node'] is not None:
+        if self.params.get('remote_node') is not None:
             self.log.info('retrive {} from remote'.format(file_name))
             self.SSH.get_file(rmt_file='/tmp/{}'.format(file_name),local_file='{}/debug/{}'.format(self.log_dir,file_name))
         else:


### PR DESCRIPTION
Signed-off-by: Yuxin Sun <yuxisun@redhat.com>

When running "os-tests -p test_general_check.TestGeneralCheck.test_collect_insights_result" it raise exception:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/os_tests-0.1.6-py3.9.egg/os_tests/tests/test_general_check.py", line 2033, in test_collect_insights_result
    if self.params['remote_node'] is not None:
KeyError: 'remote_node'
```
This patch is to fix this issue.