### PR TITLE
Update 1 case per the change in rebase 23.1.1

### DIFF
--- a/os_tests/tests/test_cloud_init.py
+++ b/os_tests/tests/test_cloud_init.py
@@ -80,7 +80,7 @@ class TestCloudInit(unittest.TestCase):
         utils_lib.run_cmd(self,
                     cmd,
                     expect_ret=0,
-                    expect_kw='ds-identify _RET=found',
+                    expect_kw='ds-identify rc=0',
                     msg='check /run/cloud-init/cloud-init-generator.log')
 
     def test_check_cloudinit_fingerprints(self):


### PR DESCRIPTION
Updated case: test_check_cloudinit_ds_identify_found
The log "ds-identify _RET=found" is deleted in cloud-init-23.1.1, so change to check log "ds-identify rc=0" which exists on both 23.1.1 and previous versions.