### PR TITLE
add case_setup parameter to allow extra setup in case

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ total 8
 ### Third party utils  
 
 Below tools are shiped under 'utils' directory with os-tests because not all systems can reach github.
-- ltp x86_64: https://github.com/liangxiao1/rpmbuild_specs/releases/download/sync_ltp_20220907/ltp-master-20220907.x86_64.rpm
-- ltp aarch64: https://github.com/liangxiao1/rpmbuild_specs/releases/download/sync_ltp_20220907/ltp-master-20220907.aarch64.rpm
-- blktests x86_64: https://github.com/liangxiao1/rpmbuild_specs/releases/download/sync_20220902/blktests-master-20220902.x86_64.rpm
-- blktests aarch64:https://github.com/liangxiao1/rpmbuild_specs/releases/download/sync_20220902/blktests-master-20220902.aarch64.rpm
+- ltp x86_64: https://github.com/liangxiao1/rpmbuild_specs/releases/latest/download/ltp-master.x86_64.rpm
+- ltp aarch64: https://github.com/liangxiao1/rpmbuild_specs/releases/latest/download/ltp-master.aarch64.rpm
+- blktests x86_64: https://github.com/liangxiao1/rpmbuild_specs/releases/latest/download/blktests-master.x86_64.rpm
+- blktests aarch64:https://github.com/liangxiao1/rpmbuild_specs/releases/latest/download/blktests-master.aarch64.rpm
 
 ### Contribution
 

--- a/os_tests/data/baseline_log.json
+++ b/os_tests/data/baseline_log.json
@@ -964,9 +964,9 @@
     },
     "msg_109": {
         "content": ".*Could not set AlternativeName.*File exists.*;.*Could not apply link config.*File exists.*",
-        "analyze": "Known issue in RHEL-8.5",
+        "analyze": "Known issue in RHEL-8.5 and fixed in rhbz#2027908",
         "branch": "rhel-8.5",
-        "status": "active",
+        "status": "closed",
         "link": "https://bugzilla.redhat.com/show_bug.cgi?id=2022432",
         "path": "journal, dmesg",
         "trigger": "el8"

--- a/os_tests/docs/os-tests_advanced_tips.md
+++ b/os_tests/docs/os-tests_advanced_tips.md
@@ -1,0 +1,53 @@
+# OS-Tests Advanced Tips
+
+os-tests is designed for catching more issue while keeping test simple, flexible and less manual effort in failure reproducing, debug information collection. This page gives some ideas with examples for different purposes in our work.
+
+## Do not clean up self provisioned test system by passing "--no-cleanup"
+
+```bash
+$ os-tests --user ec2-user --keyfile /home/xxx.pem --platform_profile /home/aws.yaml -p test_check_journalctl_fail --no-cleanup
+```
+
+## Control case run orders by passing "-p"
+
+The cases are sorted by characters as default behavior. But it follows order specified by "-p".
+Below example shows to run cloudinit tests after leap upgrade done.
+```bash
+$ os-tests --user ec2-user --keyfile /home/xxx.pem --platform_profile /home/aws.yaml -p test_leapp_upgrade_rhui,cloudinit
+```
+
+## Add extra steps to cases by passing "--case_setup"
+
+This parameter makes the os-tests move to next stage to meet various scenarios. That means user can add many things as pre-conditions to the cases.
+#### Example-1: run the same case with fips enabled
+```bash
+$ os-tests --user ec2-user --keyfile /home/xxx.pem --platform_profile /home/aws.yaml -p ltp  --case_setup fips_enable
+```
+
+#### Example-2: run a script like enable nm-cloud-setup debug mode
+
+Usually we run in normal mode to avoid too many details in test log, but it will be useful if we want to enable it in special case failure debugging.
+It might be a good idea to provide method like fips_enable, fips_disable for generic usage. But we cannot cover all, so there is no limitation by allowing file or cmd string specification.
+```bash
+$ os-tests --user ec2-user --keyfile /home/xxx.pem --platform_profile /home/aws.yaml -p test_second_ip_hotplug  --case_setup /usr/local/lib/python3.6/site-packages/os_tests/utils/debug_nm_cloud_setup.sh
+```
+
+#### Example-3: run a command like enable NetworkManager trace debug mode
+
+If you do not check journal log in one case, you can run this case with debug enabled and collect it in another case. This is also one of the case order control advantages. 
+```bash
+$ os-tests --user ec2-user --keyfile /home/xxx.pem --platform_profile /home/aws.yaml -p test_network_device_hotplug,test_check_journalctl_fail  --case_setup 'sudo nmcli general logging level TRACE domains ALL
+'
+```
+
+Note: "--case_setup" supports multiple actions separating with ',', eg. "fips_enable,$cmd1,$cmd2,$bashfile". They will be executed one by one.
+The default execution timeout is 600s, if it is not sufficient, please increase it by appending "timeout:xxx" to the string.
+
+## Add extra post steps to cases by passing "--case_post"
+
+Similar as "--case_setup", this allows user to append extra steps after the case done. We do recommend user to add the post steps to the case teardown if it is general. But we might want to run some temporary command like collect debug info after test.
+
+#### Example-1: run the case with debug enabled and collect its output
+```bash
+$ os-tests --user ec2-user --keyfile /home/xxx.pem --platform_profile /home/aws.yaml -p test_network_device_hotplug  --case_setup 'sudo nmcli general logging level TRACE domains ALL' --case_post "journalctl -u NetworkManager"
+```

--- a/os_tests/os_tests_run.py
+++ b/os_tests/os_tests_run.py
@@ -29,6 +29,8 @@ def main():
         cfg_data['remote_user'] = args.remote_user
         cfg_data['run_uuid'] = run_uuid
         cfg_data['proxy_url'] = args.proxy_url
+        cfg_data['case_setup'] = args.case_setup
+        cfg_data['case_post'] = args.case_post
         vms, disks, nics = init_provider(params=cfg_data)
     cfg_file, cfg_data = get_cfg()
     is_rmt = False
@@ -43,6 +45,8 @@ def main():
         cfg_data['remote_password'] = args.remote_password
         cfg_data['remote_keyfile'] = args.remote_keyfile
         cfg_data['proxy_url'] = args.proxy_url
+        cfg_data['case_setup'] = args.case_setup
+        cfg_data['case_post'] = args.case_post
 
     if vms:
         is_rmt = True
@@ -52,6 +56,8 @@ def main():
         cfg_data['remote_password'] = args.remote_password
         cfg_data['remote_keyfile'] = args.remote_keyfile
         cfg_data['proxy_url'] = args.proxy_url
+        cfg_data['case_setup'] = args.case_setup
+        cfg_data['case_post'] = args.case_post
 
     results_dir = cfg_data['results_dir']
     results_dir_suffix = None

--- a/os_tests/tests/test_cloud_init.py
+++ b/os_tests/tests/test_cloud_init.py
@@ -3221,6 +3221,7 @@ EOF
         utils_lib.run_cmd(self, 'sudo rpm -V cloud-init', expect_not_kw='/run/cloud-init')
 
     def tearDown(self):
+        utils_lib.finish_case(self)
         if 'test_cloudinit_sshd_keypair' in self.id():
             cmd = 'cp -f ~/.ssh/authorized_keys.bak ~/.ssh/authorized_keys'
             utils_lib.run_cmd(self, cmd, msg='restore .ssh/authorized_keys')

--- a/os_tests/tests/test_general_check.py
+++ b/os_tests/tests/test_general_check.py
@@ -671,7 +671,7 @@ itlb_multihit|grep -v 'no microcode'|grep -v retbleed|sed 's/:/^/' | column -t -
         component:
             journal
         bugzilla_id:
-            1975897,2026544
+            1975897,2026544,2022432
         is_customer_case:
             True 
         polarion_id:
@@ -2178,6 +2178,7 @@ current_device"
         utils_lib.run_cmd(self, "sudo cat /var/log/secure", expect_not_kw="Input/output error")
 
     def tearDown(self):
+        utils_lib.finish_case(self)
         pass
 
 if __name__ == '__main__':

--- a/os_tests/tests/test_general_test.py
+++ b/os_tests/tests/test_general_test.py
@@ -1349,6 +1349,7 @@ if __name__ == "__main__":
         self._test_vm_time_sync_host('migration')
 
     def tearDown(self):
+        utils_lib.finish_case(self)
         if "test_cpu_hotplug_no_workload" in self.id():
             cmd = "cat /sys/devices/system/cpu/cpu1/online"
             out = utils_lib.run_cmd(self, cmd)

--- a/os_tests/tests/test_lifecycle.py
+++ b/os_tests/tests/test_lifecycle.py
@@ -1104,6 +1104,7 @@ class TestLifeCycle(unittest.TestCase):
         utils_lib.run_cmd(self, 'dmesg', expect_kw="Restarting tasks", expect_not_kw='Call trace,Call Trace', msg="check the system is resumed")
 
     def tearDown(self):
+        utils_lib.finish_case(self)
         reboot_require = False
         addon_args = ["hpet_mmap=1", "mitigations=auto,nosmt", "usbcore.quirks=quirks=0781:5580:bk,0a5c:5834:gij",
         "nr_cpus=1","nr_cpus=2", "intel_iommu=on", "fips=1"]

--- a/os_tests/tests/test_ltp.py
+++ b/os_tests/tests/test_ltp.py
@@ -191,6 +191,7 @@ at least which ltp not handle')
         self._ltp_run(file_name="smoketest")
 
     def tearDown(self):
+        utils_lib.finish_case(self)
         utils_lib.check_log(self, "error,warn,fail,trace", log_cmd='dmesg -T', cursor=self.cursor, rmt_redirect_stdout=True)
 
 if __name__ == '__main__':

--- a/os_tests/tests/test_network_test.py
+++ b/os_tests/tests/test_network_test.py
@@ -1669,6 +1669,8 @@ COMMIT
             if end_time - start_time > 330:
                 cmd = 'sudo systemctl status nm-cloud-setup.timer'
                 utils_lib.run_cmd(self, cmd)
+                cmd = 'journalctl -u nm-cloud-setup'
+                utils_lib.run_cmd(self, cmd)
                 self.fail("expected 2nd ip {} not found in guest".format(self.vm.another_ip))
             time.sleep(25)
         cmd = 'sudo ip addr show {}'.format(self.active_nic)
@@ -1682,10 +1684,13 @@ COMMIT
             if end_time - start_time > 330:
                 cmd = 'sudo systemctl status nm-cloud-setup.timer'
                 utils_lib.run_cmd(self, cmd)
+                cmd = 'journalctl -u nm-cloud-setup'
+                utils_lib.run_cmd(self, cmd)
                 self.fail("expected 2nd ip {} not removed from guest".format(self.vm.another_ip))
             time.sleep(25)
 
     def tearDown(self):
+        utils_lib.finish_case(self)
         if 'test_mtu_min_max_set' in self.id():
             mtu_cmd = "sudo ip link set dev %s mtu %s" % (self.active_nic , self.mtu_old)
             utils_lib.run_cmd(self, mtu_cmd, expect_ret=0, msg='restore mtu')

--- a/os_tests/tests/test_storage.py
+++ b/os_tests/tests/test_storage.py
@@ -1168,6 +1168,7 @@ class TestStorage(unittest.TestCase):
         utils_lib.run_cmd(self, cmd, expect_ret=0)
 
     def tearDown(self):
+        utils_lib.finish_case(self)
         if 'test_ssd_trim' in self.id():
             if self.is_mounted:
                 utils_lib.run_cmd(self,'sudo umount /mnt')

--- a/os_tests/tests/test_update.py
+++ b/os_tests/tests/test_update.py
@@ -470,6 +470,7 @@ class TestUpgrade(unittest.TestCase):
         if x_version_upgrade != x_version + 1:
             self.FailTest('Leapp upgrade failed since did not upgrade to target release')
     def tearDown(self):
+        utils_lib.finish_case(self)
         pass
 
 if __name__ == '__main__':

--- a/os_tests/utils/debug_nm_cloud_setup.sh
+++ b/os_tests/utils/debug_nm_cloud_setup.sh
@@ -1,0 +1,13 @@
+# enable nm-cloud-setup
+set -x
+debug_file="/usr/lib/systemd/system/nm-cloud-setup.service.d/10-enable-debug-trace.conf"
+if [ -s $debug_file ]; then
+    echo "${debug_file} exists, exit"
+    exit 0
+fi
+cat <<EOF > /usr/lib/systemd/system/nm-cloud-setup.service.d/10-enable-debug-trace.conf
+[Service]
+Environment=NM_CLOUD_SETUP_LOG=TRACE
+EOF
+systemctl daemon-reload
+systemctl restart nm-cloud-setup

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     package_data={
         'os_tests': [
             'cfg/*',
+            'docs/*',
             'data/*',
             'templates/*',
             'utils/*'


### PR DESCRIPTION
Below is an example that run test with fips enabled. $ os-tests --user ec2-user --keyfile /home/virtqe_s1.pem --platform_profile /home/aws.yaml -p cloudinit --case_setup fips_enable