### PR TITLE
Add "version support" to cloud-init case

### DIFF
--- a/os_tests/cfg/alicloud.yaml
+++ b/os_tests/cfg/alicloud.yaml
@@ -38,3 +38,6 @@ Flavor:
     nic_count: 3
     disk_quantity: 9
     arch: x86_64
+# Add case name into support cases if support versions are undefined when testing fixed scratch build
+# For example ["case1","case2"]
+support_cases: None

--- a/os_tests/cfg/aws.yaml
+++ b/os_tests/cfg/aws.yaml
@@ -37,3 +37,6 @@ cpus: None
 memory: None
 disks: None
 net_bandwidth: None
+# Add case name into support cases if support versions are undefined when testing fixed scratch build
+# For example ["case1","case2"]
+support_cases: None

--- a/os_tests/cfg/nutanix.yaml
+++ b/os_tests/cfg/nutanix.yaml
@@ -55,3 +55,6 @@ Flavor:
   memory: 
   size: 
   virt: 
+# Add case name into support cases if support versions are undefined when testing fixed scratch build
+# For example ["case1","case2"]
+support_cases: None

--- a/os_tests/cfg/openstack.yaml
+++ b/os_tests/cfg/openstack.yaml
@@ -36,3 +36,6 @@ Flavor:
   memory: 4
   size: 40G
   virt: kvm
+# Add case name into support cases if support versions are undefined when testing fixed scratch build
+# For example ["case1","case2"]
+support_cases: None

--- a/os_tests/libs/resources.py
+++ b/os_tests/libs/resources.py
@@ -23,6 +23,7 @@ class BaseResource(metaclass=ABCMeta):
         # mark the resource created, default is os_tests
         self.tag = 'os_tests'
         self.provider = params['Cloud']['provider']
+        self.support_cases = params['support_cases']
         self.id = 0
 
     @abstractmethod

--- a/os_tests/libs/version_util.py
+++ b/os_tests/libs/version_util.py
@@ -1,0 +1,38 @@
+from packaging.version import Version, parse
+import re
+
+def comparetolist(current_version,support_versions):
+    if support_versions is None:
+        return False
+    ver1 = parse(current_version)
+    ver = re.split(".el(\d+_*\d*)\.*",current_version)
+    #ver  ['22.1-6', '10_7', '3']
+    for support_version in support_versions:
+        ver2 = parse(support_version)
+        support_ver = re.split(".el(\d+_*\d*)\.*",support_version)
+        if ver[1] == support_ver[1]:
+            return ver1 >= ver2
+    return False
+
+def get_version(rpmversion,prestr):
+    #split .noarch  .x86_64
+    version = rpmversion.rsplit(".", 1)[0]
+    ver = version.split(prestr)[1]
+    return ver
+
+def is_support(version,case_name,support_cases,main_support_versions,backport_versions):
+    if support_cases is not None and case_name in support_cases:
+        return True
+    if "_" in version:
+        pre_ver = version.split('_')[0]
+        if comparetolist(pre_ver,main_support_versions):
+            return True
+        elif comparetolist(version, backport_versions):
+             return True
+        else:
+            return False
+    else:
+        if comparetolist(version,main_support_versions):
+            return True
+        else:
+            return False


### PR DESCRIPTION
1. new file os_tests/libs/version_util.py
2. add a parameter support_cases  to os_tests/libs/resources.py
3. update case test_cloudinit_check_previous_hostname with support version