### PR TITLE
Update a cloud init case and some cases docs.

### DIFF
--- a/os_tests/tests/test_cloud_init.py
+++ b/os_tests/tests/test_cloud_init.py
@@ -2655,8 +2655,6 @@ chpasswd:
         debug_want:
             N/A
         """
-        if utils_lib.is_aws(self):
-            self.skipTest('Temporary skip on aws platform since there is a connection issue after removing the cloud-init files')
         # Mount /tmp /var/tmp with noexec option
         utils_lib.run_cmd(self, "sudo dd if=/dev/zero of=/var/tmp.partition bs=1024 count=1024000")
         utils_lib.run_cmd(self, "sudo /sbin/mke2fs /var/tmp.partition ")
@@ -2667,7 +2665,8 @@ chpasswd:
         utils_lib.run_cmd(self, "sudo bash -c 'echo /tmp /var/tmp none rw,noexec,nosuid,nodev,bind 0 0 >> /etc/fstab'")
         utils_lib.run_cmd(self, "sudo rm -rf /var/lib/cloud/instance /var/lib/cloud/instances/* /var/log/cloud-init.log")
         # Restart VM
-        self.vm.reboot(wait=True)
+        # self.vm.reboot(wait=True)
+        utils_lib.run_cmd(self, 'sudo reboot', msg='reboot system under test')
         time.sleep(30)
         utils_lib.init_connection(self, timeout=1200)
         # Verify cloud-init.log
@@ -2702,8 +2701,6 @@ chpasswd:
         """
         if float(self.rhel_x_version) >= 9.0:
             self.skipTest('skip run this case, network-script is not be supported by rhel 9 any more')
-        if utils_lib.is_aws(self):
-            self.skipTest('Temporary skip on aws platform since there is a connection issue after removing the cloud-init files')    
         pkg_install_check = utils_lib.is_pkg_installed(self,"network-scripts")
         if not pkg_install_check and self.vm.provider == 'openstack':
             # Register to rhsm stage
@@ -2736,7 +2733,8 @@ chpasswd:
                                              /var/log/cloud-init.log")
             self.log.info(err)
         # Restart VM and verify connection
-        self.vm.reboot(wait=True)
+        # self.vm.reboot(wait=True)
+        utils_lib.run_cmd(self, 'sudo reboot', msg='reboot system under test')
         time.sleep(30)
         utils_lib.init_connection(self, timeout=1200)
         #saw activating (start) in CI log, change to loop check.
@@ -2947,7 +2945,8 @@ chpasswd:
         output = utils_lib.run_cmd(self, cmd, msg="Updated network configuration.")
         cmd = 'sudo rm /run/cloud-init/ /var/lib/cloud/* -rf'
         utils_lib.run_cmd(self, cmd, msg='clean cloud-init and redo it')
-        self.vm.reboot()
+        #self.vm.reboot()
+        utils_lib.run_cmd(self, 'sudo reboot', msg='reboot system under test')
         time.sleep(20)
         utils_lib.init_connection(self, timeout=self.ssh_timeout)
         cmd = 'cat /etc/sysconfig/network'

--- a/os_tests/tests/test_cloud_init.py
+++ b/os_tests/tests/test_cloud_init.py
@@ -2641,7 +2641,7 @@ chpasswd:
         bugzilla_id:
             1857309
         is_customer_case:
-            False
+            True
         testplan:
             N/A
         maintainer:
@@ -2655,14 +2655,16 @@ chpasswd:
         debug_want:
             N/A
         """
+        if utils_lib.is_aws(self):
+            self.skipTest('Temporary skip on aws platform since there is a connection issue after removing the cloud-init files')
         # Mount /tmp /var/tmp with noexec option
         utils_lib.run_cmd(self, "sudo dd if=/dev/zero of=/var/tmp.partition bs=1024 count=1024000")
         utils_lib.run_cmd(self, "sudo /sbin/mke2fs /var/tmp.partition ")
         utils_lib.run_cmd(self, "sudo mount -o loop,noexec,nosuid,rw /var/tmp.partition /tmp")
         utils_lib.run_cmd(self, "sudo chmod 1777 /tmp")
         utils_lib.run_cmd(self, "sudo mount -o rw,noexec,nosuid,nodev,bind /tmp /var/tmp")
-        utils_lib.run_cmd(self, "sudo echo '/var/tmp.partition /tmp ext2 loop,noexec,nosuid,rw 0 0' >> /etc/fstab")
-        utils_lib.run_cmd(self, "sudo echo '/tmp /var/tmp none rw,noexec,nosuid,nodev,bind 0 0' >> /etc/fstab")
+        utils_lib.run_cmd(self, "sudo bash -c 'echo /var/tmp.partition /tmp ext2 loop,noexec,nosuid,rw 0 0 >> /etc/fstab'")
+        utils_lib.run_cmd(self, "sudo bash -c 'echo /tmp /var/tmp none rw,noexec,nosuid,nodev,bind 0 0 >> /etc/fstab'")
         utils_lib.run_cmd(self, "sudo rm -rf /var/lib/cloud/instance /var/lib/cloud/instances/* /var/log/cloud-init.log")
         # Restart VM
         self.vm.reboot(wait=True)
@@ -2700,6 +2702,8 @@ chpasswd:
         """
         if float(self.rhel_x_version) >= 9.0:
             self.skipTest('skip run this case, network-script is not be supported by rhel 9 any more')
+        if utils_lib.is_aws(self):
+            self.skipTest('Temporary skip on aws platform since there is a connection issue after removing the cloud-init files')    
         pkg_install_check = utils_lib.is_pkg_installed(self,"network-scripts")
         if not pkg_install_check and self.vm.provider == 'openstack':
             # Register to rhsm stage

--- a/os_tests/tests/test_general_check.py
+++ b/os_tests/tests/test_general_check.py
@@ -1695,7 +1695,7 @@ in cmdline as bug1859088")
         subsystem_team:
             sst_virtualization_cloud
         automation_drop_down:
-            Automated
+            automated
         linked_work_items:
             N/A
         automation_field:
@@ -1715,7 +1715,7 @@ in cmdline as bug1859088")
         test_type:
             Functional
         test_level:
-            Component
+            component
         maintainer:
             xiliang@redhat.com
         description: |

--- a/os_tests/tests/test_general_test.py
+++ b/os_tests/tests/test_general_test.py
@@ -162,7 +162,7 @@ current_clocksource'
         subsystem_team:
             sst_virtualization_cloud
         automation_drop_down:
-            Automated
+            automated
         linked_work_items:
             N/A
         automation_field:
@@ -182,7 +182,7 @@ current_clocksource'
         test_type:
             Functional
         test_level:
-            Component
+            component
         maintainer:
             xiliang@redhat.com
         description: |
@@ -416,7 +416,7 @@ int main(int argc, char *argv[])
         bugzilla_id:
             1932802, 1905398
         is_customer_case:
-            <optional: True or False>
+            False
         maintainer:
             xiliang@redhat.com
         description:
@@ -1148,7 +1148,7 @@ if __name__ == "__main__":
         subsystem_team:
             sst_virtualization_cloud
         automation_drop_down:
-            Automated
+            automated
         linked_work_items:
             N/A
         automation_field:
@@ -1168,7 +1168,7 @@ if __name__ == "__main__":
         test_type:
             Functional
         test_level:
-            Component
+            component
         maintainer:
             minl@redhat.com
         description: |
@@ -1252,7 +1252,7 @@ if __name__ == "__main__":
         subsystem_team:
             sst_virtualization_cloud
         automation_drop_down:
-            Automated
+            automated
         linked_work_items:
             N/A
         automation_field:
@@ -1272,7 +1272,7 @@ if __name__ == "__main__":
         test_type:
             Functional
         test_level:
-            Component
+            component
         maintainer:
             minl@redhat.com
         description: |
@@ -1309,7 +1309,7 @@ if __name__ == "__main__":
         subsystem_team:
             sst_virtualization_cloud
         automation_drop_down:
-            Automated
+            automated
         linked_work_items:
             N/A
         automation_field:
@@ -1329,7 +1329,7 @@ if __name__ == "__main__":
         test_type:
             Functional
         test_level:
-            Component
+            component
         maintainer:
             minl@redhat.com
         description: |

--- a/os_tests/tests/test_lifecycle.py
+++ b/os_tests/tests/test_lifecycle.py
@@ -173,7 +173,7 @@ class TestLifeCycle(unittest.TestCase):
         test_type:
             functional
         test_level:
-            Component
+            component
         maintainer:
             xiliang@redhat.com
         description: |

--- a/os_tests/tests/test_network_test.py
+++ b/os_tests/tests/test_network_test.py
@@ -47,33 +47,25 @@ class TestNetworkTest(unittest.TestCase):
         '''
         case_name:
             test_ethtool_G
-
         case_priority:
             1
-
         component:
             kernel
-
         bugzilla_id:
             1722628
-
         polarion_id:
             n/a
-
         maintainer:
             xiliang@redhat.com
-
         description:
             Use ethtool to change the rx/tx ring parameters of the specified network device.
-
-        key_steps:
+        key_steps: |
             1. # ethtool -g $nic
             2. # ethtool -G $nic rx $num
             3. # ethtool -G $nic rx-mini $num
             4. # ethtool -G $nic rx-jumbo $num
             5. # ethtool -G $nic tx $num
-
-        expected_result:
+        expected_result: |
             Can change the supported rx/tx ring parameters of the specified network device.
             Cannot set the ring parameters to -1.
             eg. # ethtool -G eth0 rx 512
@@ -91,7 +83,6 @@ class TestNetworkTest(unittest.TestCase):
                 TX:		1024
                 # ethtool -G eth0 rx -1
                 no ring parameters changed, aborting
-
         '''
         self.log.info("Test change rx/tx ring setting.")
         query_cmd = "ethtool -g {}".format(self.active_nic )
@@ -205,7 +196,7 @@ class TestNetworkTest(unittest.TestCase):
         bug_id:
             N/A
         is_customer_case:
-            N/A
+            False 
         testplan:
             N/A
         maintainer:
@@ -266,7 +257,7 @@ class TestNetworkTest(unittest.TestCase):
         subsystem_team:
             sst_virtualization_cloud
         automation_drop_down:
-            Automated
+            automated
         linked_work_items:
             N/A
         automation_field:
@@ -349,7 +340,7 @@ class TestNetworkTest(unittest.TestCase):
         test_type:
             functional
         test_level:
-            Component
+            component
         maintainer:
             xiliang@redhat.com
         description: |

--- a/os_tests/tests/test_rhel_cert.py
+++ b/os_tests/tests/test_rhel_cert.py
@@ -105,7 +105,7 @@ class TestRHELCert(unittest.TestCase):
         subsystem_team:
             sst_virtualization_cloud
         automation_drop_down:
-            Automated
+            automated
         linked_work_items:
             jira_RHELBU-1991
         automation_field:

--- a/os_tests/tests/test_rhel_guest_image.py
+++ b/os_tests/tests/test_rhel_guest_image.py
@@ -609,9 +609,9 @@ class TestGuestImage(unittest.TestCase):
         component:
             rhel-guest-image
         bugzilla_id:
-            1144155
+            1144155,1729869
         is_customer_case:
-            False
+            True
         testplan:
             N/A
         maintainer:
@@ -621,7 +621,7 @@ class TestGuestImage(unittest.TestCase):
         key_steps:
             1. cat /proc/cmdline
         expect_result:
-            no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 crashkernel=
+            no_timer_check console=ttyS0,115200n8 net.ifnames=0 crashkernel=
         debug_want:
             N/A
         """


### PR DESCRIPTION
1. Update test_cloudinit_mount_with_noexec_option to fix the "Permission denied" issue when running echo command with normal user.
2. Temporary disable 2 cloudinit cases on aws platform to avoid the connection issue.
3. Update some cases doc to fix the case importing issue.