### PR TITLE
set packaging version <= 21.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     },
     include_package_data=True,
     #data_files=[('/'+os.path.expanduser("~"), ['cfg/os-tests.yaml']),],
-    install_requires=['PyYAML', 'Jinja2<=2.11.3', 'tipset>=0.0.15', 'markupsafe<=1.1.1', 'packaging'],
+    install_requires=['PyYAML', 'Jinja2<=2.11.3', 'tipset>=0.0.15', 'markupsafe<=1.1.1', 'packaging<=21.3'],
     license="GPLv3+",
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',


### PR DESCRIPTION
Setting packaging version <= 21.3 because of below change making cloud-init case test_cloudinit_check_previous_hostname fail.
- packaging 22.0  Drop LegacySpecifier and LegacyVersion by @pradyunsg in #407