### PR TITLE
Add parameters for rhsm, add is_log_cmd to not display cmd.

### DIFF
--- a/os_tests/cfg/aws.yaml
+++ b/os_tests/cfg/aws.yaml
@@ -44,3 +44,5 @@ net_bandwidth: None
 # Add case name into support cases if support versions are undefined when testing fixed scratch build
 # For example ["case1","case2"]
 support_cases: None
+subscription_username:
+subscription_password:

--- a/os_tests/cfg/os-tests.yaml
+++ b/os_tests/cfg/os-tests.yaml
@@ -27,4 +27,6 @@ remote_user: ec2-user
 # ssh key file location for remote access
 remote_keyfile: 
 # or password for remote access
-remote_password: 
+remote_password:
+subscription_username:
+subscription_password:

--- a/os_tests/libs/resources_aws.py
+++ b/os_tests/libs/resources_aws.py
@@ -77,6 +77,8 @@ class EC2VM(VMResource):
         # efa_support default set to False, will query instance property next
         self.efa_support = False
         self.volume_size = params.get('volume_size') or 10
+        self.subscription_username = params.get('subscription_username')
+        self.subscription_password = params.get('subscription_password')
 
     def show(self):
         if self.is_exist():

--- a/os_tests/tests/test_update.py
+++ b/os_tests/tests/test_update.py
@@ -585,10 +585,10 @@ class TestUpgrade(unittest.TestCase):
         x_version = self.rhel_x_version
         #Register to rhsm
         self.log.info("Register to rhsm")
-        reg_cmd = "sudo subscription-manager register --username {0} --password {1}".format(
-            self.vm.subscription_username,
-            self.vm.subscription_password)
-        utils_lib.run_cmd(self, reg_cmd, expect_ret=0)
+        reg_cmd = "sudo subscription-manager register --username {0} --password {1} --force".format(
+            self.params.get('subscription_username'),
+            self.params.get('subscription_password')) 
+        utils_lib.run_cmd(self, reg_cmd, is_log_cmd=False, expect_ret=0)
         #Configure manage_repos to 1 to enable rhsm repo
         cmd = "sed -i 's/manage_repos = 0/manage_repos = 1/g' /etc/rhsm/rhsm.conf"
         utils_lib.run_cmd(self,


### PR DESCRIPTION
1. Add parameters for rhsm, you can define them in aws.yaml, os-tests.yaml or in cmd line.
2. Don't display the value of rhsm parameters in test log.
3. Add is_log_cmd in run_cmd, if you don't want to display the cmd, set is_log_cmd=False in case.