### PR TITLE
call check_log in avc test cases

### DIFF
--- a/os_tests/data/baseline_log.json
+++ b/os_tests/data/baseline_log.json
@@ -1762,5 +1762,23 @@
         "link": "https://bugzilla.redhat.com/show_bug.cgi?id=2227536",
         "path": "journal",
         "trigger": ""
+    },
+    "msg_198": {
+        "content": ".*rhc-worker-playbook.worker.*",
+        "analyze": "known avc log",
+        "branch": "rhel",
+        "status": "active",
+        "link": "https://bugzilla.redhat.com/show_bug.cgi?id=2188231",
+        "path": "journal",
+        "trigger": ""
+    },
+    "msg_199": {
+        "content": ".*GDS: Unknown: Dependent on hypervisor status.*",
+        "analyze": "Controlled by the host:Running on a virtual guest processor that is affected but with no way to know if host processor is mitigated or vulnerable.",
+        "branch": "rhel",
+        "status": "active",
+        "link": "https://www.kernel.org/doc/html/next/admin-guide/hw-vuln/gather_data_sampling.html",
+        "path": "journal",
+        "trigger": ""
     }
 }

--- a/os_tests/libs/utils_lib.py
+++ b/os_tests/libs/utils_lib.py
@@ -1159,7 +1159,8 @@ def get_cmd_cursor(test_instance, cmd='dmesg -T', rmt_redirect_stdout=False, rmt
     test_instance.log.info("Get cursor: {}".format(cursor))
     return cursor
 
-def check_log(test_instance, log_keyword, log_cmd="journalctl -b 0", match_word_exact=False, cursor=None, skip_words=None, rmt_redirect_stdout=False, rmt_redirect_stderr=False, rmt_get_pty=False, msg=None):
+def check_log(test_instance, log_keyword, log_cmd="journalctl -b 0", expect_ret=None,
+            expect_not_ret=None, match_word_exact=False, cursor=None, skip_words=None, rmt_redirect_stdout=False, rmt_redirect_stderr=False, rmt_get_pty=False, msg=None):
     '''
     check journal log
     Arguments:
@@ -1192,7 +1193,8 @@ def check_log(test_instance, log_keyword, log_cmd="journalctl -b 0", match_word_
     if cursor is not None:
         out = run_cmd(test_instance,
                       check_cmd,
-                      expect_ret=0,
+                      expect_ret=expect_ret,
+                      expect_not_ret= expect_not_ret,
                       msg='Get log......', cursor=cursor,
                       rmt_redirect_stderr=rmt_redirect_stderr,
                       rmt_redirect_stdout=rmt_redirect_stdout,
@@ -1200,7 +1202,8 @@ def check_log(test_instance, log_keyword, log_cmd="journalctl -b 0", match_word_
     else:
         out = run_cmd(test_instance,
                       check_cmd,
-                      expect_ret=0,
+                      expect_ret=expect_ret,
+                      expect_not_ret= expect_not_ret,
                       msg='Get log......',
                       rmt_redirect_stderr=rmt_redirect_stderr,
                       rmt_redirect_stdout=rmt_redirect_stdout,

--- a/os_tests/tests/test_general_check.py
+++ b/os_tests/tests/test_general_check.py
@@ -66,7 +66,8 @@ class TestGeneralCheck(unittest.TestCase):
         cmd = "rpm -qa selinux\* container\* | sort"
         utils_lib.run_cmd(self, cmd, msg='please attach this log if bug is found')
         cmd = "sudo ausearch -m AVC -ts today -i"
-        utils_lib.run_cmd(self, cmd, expect_not_ret=0, msg='Checking avc log!', rmt_get_pty=True)
+        #utils_lib.run_cmd(self, cmd, expect_not_ret=0, msg='Checking avc log!', rmt_get_pty=True)
+        utils_lib.check_log(self, 'PROCTITLE', expect_not_ret=0, log_cmd=cmd, rmt_get_pty=True)
 
     def test_check_avclog_nfs(self):
         """
@@ -120,7 +121,8 @@ class TestGeneralCheck(unittest.TestCase):
 
         time.sleep(10)
         cmd = "sudo ausearch -i -m AVC -ts today {}".format(time_start)
-        utils_lib.run_cmd(self, cmd, expect_not_ret=0, msg='check if new avc log generated', rmt_get_pty=True)
+        #utils_lib.run_cmd(self, cmd, expect_not_ret=0, msg='check if new avc log generated', rmt_get_pty=True)
+        utils_lib.check_log(self, 'PROCTITLE', expect_not_ret=0, log_cmd=cmd, rmt_get_pty=True)
 
     def test_check_available_clocksource(self):
         """


### PR DESCRIPTION
This change filter the known avc logs out instead of checking ret only.