### PR TITLE
Update case test_cloudinit_auto_register_with_subscription_manager

### DIFF
--- a/os_tests/tests/test_cloud_init.py
+++ b/os_tests/tests/test_cloud_init.py
@@ -2339,9 +2339,9 @@ rh_subscription:
         debug_want:
             N/A
         """
-        for attrname in ['subscription_username', 'subscription_password']:
-            if not hasattr(self.vm, attrname):
-                self.skipTest("no {} for {} vm".format(attrname, self.vm.provider))
+        # skip this case for public cloud, will update the case when it's suitable for public cloud
+        if self.vm.provider != 'openstack' and self.vm.provider != 'nutanix':
+            self.skipTest('skip run as this case need connect rhsm stage server, not suitable for public cloud')
         CONFIG='''rh_subscription:
     username: {}
     password: {}


### PR DESCRIPTION
skip this case for public cloud, especially aws, because of aws has parameters for rhsm now.  (https://github.com/virt-s1/os-tests/commit/9c88d0a3d5b386097ad8137c8b65757ddc40a07d)