### PR TITLE
Match cdrom more accurate in 'test_wipefs_cdrom'

### DIFF
--- a/os_tests/tests/test_general_test.py
+++ b/os_tests/tests/test_general_test.py
@@ -1026,7 +1026,7 @@ if __name__ == "__main__":
         debug_want:
             "strace -o log wipefs -a /dev/srN
         """
-        cmd = "lsblk | grep sr"
+        cmd = "lsblk | grep -E 'sr[0-9]'"
         all = utils_lib.run_cmd(self,cmd,cancel_kw="sr0",
                                 msg="check if machine mounted CDROM").rstrip().split("\n")
         self.cursor = utils_lib.get_cmd_cursor(self, cmd='journalctl -b0', rmt_redirect_stdout=True)


### PR DESCRIPTION
In LVM file system, lsblk|grep sr may match '/usr' which makes the dev is empty in the first loop.
```
$ lsblk | grep sr
  ├─rootvg-usrlv  253:3    0   10G  0 lvm  /usr
sr0                11:0    1  628K  0 rom  
```
After fix:
```
$ lsblk | grep -E 'sr[0-9]'
sr0                11:0    1  628K  0 rom  
```