### PR TITLE
Fix cloud-config user-data to avoid schema warning

### DIFF
--- a/os_tests/libs/resources_openstack.py
+++ b/os_tests/libs/resources_openstack.py
@@ -78,7 +78,7 @@ runcmd:
 
 password: {1}
 chpasswd: {{ expire: False }}
-ssh_pwauth: 0
+ssh_pwauth: False
 """.format(self.run_uuid, 'R')
     
         # VM creation parameter for rhsm subscription related cases

--- a/os_tests/tests/test_cloud_init.py
+++ b/os_tests/tests/test_cloud_init.py
@@ -1711,7 +1711,7 @@ EOF""".format(device, size), expect_ret=0)
 user: {0}
 password: {1}
 chpasswd: {{ expire: False }}
-ssh_pwauth: 1
+ssh_pwauth: True
 """.format(self.vm.vm_username, self.vm.vm_password)       
         self.vm.keypair = None
         self.vm.create()


### PR DESCRIPTION
In the latest cloud-init 23.1.1, there is schema checking cloud-config, and there is warning about ssh_pwauth: 0, it should be ssh_pwauth: False.
Changing the ssh_pwauth: 0 to ssh_pwauth: False, no warning anymore, and it is compatible with old cloud-init versions.