### PR TITLE
Update two cases per the latest test results

### DIFF
--- a/os_tests/libs/resources_openstack.py
+++ b/os_tests/libs/resources_openstack.py
@@ -153,7 +153,7 @@ ssh_pwauth: False
                     server=server, wait=self.create_timeout)
             else:
                 server = self.conn.compute.wait_for_server(server)
-            if auto_ip and self.floating_network_id != '':
+            if auto_ip and self.floating_network_id != '' and self.floating_network_id is not None:
                 f_ip = self.conn.network.create_ip(
                     floating_network_id=self.floating_network_id)
                 self.conn.compute.add_floating_ip_to_server(

--- a/os_tests/tests/test_cloud_init.py
+++ b/os_tests/tests/test_cloud_init.py
@@ -3512,7 +3512,7 @@ ssh_authorized_keys:
         ret = utils_lib.run_cmd(self, cmd, expect_kw='status: done', ret_status=True, msg='cloud-init status should be done')        
         # check cloud-init status return code is 0. If not 0, print recoverable_errors
         if ret != 0:
-            debugcmd = 'cloud-init status --format json | jq .recoverable_errors'
+            debugcmd = 'cloud-init status --format json'
             output = utils_lib.run_cmd(self, debugcmd)
             self.fail("The cloud-init status return code is {}, The recoverable_errors are:\n{}".format(ret, output))   
 
@@ -3523,7 +3523,8 @@ ssh_authorized_keys:
             if float(product_id) < 9.0:
                 self.vm.delete(wait=True)
                 self.vm.create(wait=True)
-                self.vm.start(wait=True)
+                if self.vm.is_stopped():
+                    self.vm.start(wait=True)
                 time.sleep(30)
                 utils_lib.init_connection(self, timeout=self.ssh_timeout)
         if 'test_cloudinit_no_networkmanager' in self.id():


### PR DESCRIPTION
1. There is no jq command in rhel-8.10 by default, so changing the debug command. No effect for the debug info
2. Update openstack resource file to support self.vm.create(wait=True) well, and adding condition check when run self.vm.start(wait=True)