### PR TITLE
teardown refactor and vm create expansion

### DIFF
--- a/os_tests/cfg/aws.yaml
+++ b/os_tests/cfg/aws.yaml
@@ -17,6 +17,7 @@ security_group_ids :
 placement_group_name : 
 ssh_key_name : 
 username: ec2-user
+vm_password:
 # optional, default is os_tests_aws
 tagname : os_tests_aws
 # optional(imdsv1 and v2)|required(imdsv2 only)

--- a/os_tests/libs/resources_nutanix.py
+++ b/os_tests/libs/resources_nutanix.py
@@ -800,12 +800,16 @@ class NutanixVM(VMResource):
                 logging.error("progress status of task is Failed")
                 break
 
-    def create(self, single_nic=True, wait=True, vm_name=None):
+    def create(self, single_nic=True, wait=True, vm_name=None, userdata=None, sshkey=None):
         logging.info("Create VM, single_nic is " + str(single_nic))
+        sshkey= sshkey or self.ssh_pubkey
+        if sshkey == "DoNotSet" :
+            sshkey = None
+        userdata = userdata or self.user_data
         self.prism.vm_user_data = self.vm_user_data
-        self.prism.user_data = self.user_data
+        self.prism.user_data = userdata
         self.prism.vm_custom_file = self.vm_custom_file
-        res = self.prism.create_vm(self.ssh_pubkey, single_nic, vm_name)
+        res = self.prism.create_vm(sshkey, single_nic, vm_name)
         if wait:
             self.wait_for_status(
                 res['task_uuid'], 60,

--- a/os_tests/libs/utils_lib.py
+++ b/os_tests/libs/utils_lib.py
@@ -357,6 +357,7 @@ def init_case(test_instance):
     test_instance.log.info("-"*80)
     test_instance.ssh_timeout = 180
     test_instance.default_boot_index = None
+    test_instance.skipflag = False
     if test_instance.vm:
         if test_instance.vm.dead_count > 4:
             test_instance.fail("cannot connect to vm over 4 times, skip retry")

--- a/os_tests/os_tests_run.py
+++ b/os_tests/os_tests_run.py
@@ -153,8 +153,9 @@ def main():
                 if i.id:
                     log.info(i.id)
             break
-        if hasattr(res, 'exists') and res.exists():
-            res.delete()
+        if hasattr(res, 'exists'):
+            if res.exists():
+                res.delete()
         elif hasattr(res, 'is_exist') and res.is_exist():
             res.delete()
 if __name__ == "__main__":


### PR DESCRIPTION
do vm detete and subscription unregister in teardown, added skip flag
- delete vm because it effects other cases
  > test_cloudinit_create_vm_config_drive: effects datasource check
  > test_cloudinit_login_with_password: effects other cases to ssh login with key
  > test_cloudinit_login_with_password_userdata
- delete vm in case it fails and effects other cases
  > test_cloudinit_sshd_keypair
  > test_cloudinit_no_networkmanager
  > test_cloudinit_mount_with_noexec_option
  > test_cloudinit_disable_cloudinit
  > test_cloudinit_auto_install_package_with_subscription_manager
  > test_cloudinit_verify_rh_subscription_enablerepo_disablerepo
  > test_cloudinit_check_previous_hostname
- not effect other cases, those may be effected, already recreate vm, so do not need delete vm in teardown
  > test_cloudinit_create_vm_two_nics
  > test_cloudinit_create_vm_stateless_ipv6
  > test_cloudinit_create_vm_stateful_ipv6
- subscription unregister
  >test_cloudinit_auto_install_package_with_subscription_manager
  >test_cloudinit_verify_rh_subscription_enablerepo_disablerepo
  >test_cloudinit_auto_register_with_subscription_manager
  >test_cloudinit_no_networkmanager
- other cases updated
  >test_cloudinit_create_vm_ipv6only: skip flag and user_data
  >test_cloudinit_check_config_ipv6: add ipv6 ping check on aws

vm create mothod, added parameters,
- resources_openstack.py  vm.create  userdata=None, sshkey=None, configdrive=False, second_nic=None
- resources_aws.py   vm.create  userdata=None, sshkey=None
- resources_nutanix.py   vm.create  userdata=None, sshkey=None

others
- os_tests_run.py  fix the error when hasattr(res, 'exists') but not res.exists() and do not hasattr(res, 'is_exist')
- openstack.py  output log when create and delete vm