### PR TITLE
Add rhsm is_rhsm_registered, enable_auto_registration, rhsm_register,…

### DIFF
--- a/os_tests/tests/test_rhel_cert.py
+++ b/os_tests/tests/test_rhel_cert.py
@@ -112,6 +112,7 @@ class TestRHELCert(unittest.TestCase):
             cmd = 'sudo bash -c "rm -rf /var/rhcert/*"'
             utils_lib.run_cmd(self, cmd, msg='cleanup prior test result')
         else:
+            '''
             if os.getenv('INFRA_PROVIDER') == 'ali':
                 #Register to rhsm
                 self.log.info("Register to rhsm")
@@ -130,6 +131,9 @@ class TestRHELCert(unittest.TestCase):
                     utils_lib.run_cmd(self, cmd, timeout=600, expect_ret=0)
                     utils_lib.run_cmd(self, cmd, timeout=600, rmt_node=self.params['remote_nodes'][-1], expect_ret=0)
                 time.sleep(180)
+            '''
+            utils_lib.rhsm_register(self, cancel_case=True)
+            utils_lib.rhsm_register(self, cancel_case=True, rmt_node=self.params['remote_nodes'][-1])
             cmds_enablerepo = [ "sudo subscription-manager status",
                                 "sudo sleep 10",
                                 "sudo subscription-manager config --rhsm.manage_repos=1",
@@ -144,9 +148,8 @@ class TestRHELCert(unittest.TestCase):
                 utils_lib.run_cmd(self, cmd, timeout=600, rmt_node=self.params['remote_nodes'][-1], expect_ret=0)
             rpm_pkgs_rhcert = ["redhat-certification", "redhat-certification-hardware", "redhat-certification-backend", "redhat-certification-cloud"]
             for rpm_pkg in rpm_pkgs_rhcert:
-                utils_lib.is_pkg_installed(self, timeout=600, pkg_name=rpm_pkg)
-            cmd = 'sudo yum install -y redhat-certification redhat-certification-hardware redhat-certification-cloud'
-            utils_lib.run_cmd(self, cmd, timeout=600, rmt_node=self.params['remote_nodes'][-1])
+                utils_lib.is_pkg_installed(self, timeout=600, pkg_name=rpm_pkg, is_install=True, cancel_case=True)
+                utils_lib.is_pkg_installed(self, timeout=600, pkg_name=rpm_pkg, is_install=True, cancel_case=True, rmt_node=self.params['remote_nodes'][-1])
         cmd = 'sudo bash -c "mkdir -p /var/www/rhcert/export/var/crash"'
         utils_lib.run_cmd(self, cmd, rmt_node=self.params['remote_nodes'][-1])
         cmd = 'sudo bash -c "chmod -R 777 /var/www/rhcert/export/"'

--- a/os_tests/tests/test_update.py
+++ b/os_tests/tests/test_update.py
@@ -596,18 +596,8 @@ class TestUpgrade(unittest.TestCase):
                         expect_ret=0,
                         msg='check current rhel release')
         x_version = self.rhel_x_version
-        #Register to rhsm
-        self.log.info("Register to rhsm")
-        reg_cmd = "sudo subscription-manager register --username {0} --password {1} --force".format(
-            self.params.get('subscription_username'),
-            self.params.get('subscription_password')) 
-        utils_lib.run_cmd(self, reg_cmd, timeout=600, is_log_cmd=False, expect_ret=0)
-        #Configure manage_repos to 1 to enable rhsm repo
-        cmd = "sed -i 's/manage_repos = 0/manage_repos = 1/g' /etc/rhsm/rhsm.conf"
-        utils_lib.run_cmd(self,
-                        "sudo bash -c \"{}\"".format(cmd),
-                        expect_ret=0,
-                        msg='configure manage_repos')
+        #Register to RHSM
+        utils_lib.rhsm_register(self, cancel_case=True)
         #Update
         utils_lib.run_cmd(self,
                         "sudo yum update -y",
@@ -687,7 +677,6 @@ class TestUpgrade(unittest.TestCase):
         x_version_upgrade = self.rhel_x_version
         if x_version_upgrade != x_version + 1:
             self.FailTest('Leapp upgrade failed since did not upgrade to target release')
-
 
     def tearDown(self):
         utils_lib.finish_case(self)


### PR DESCRIPTION
1. Add functions of rhsm is_rhsm_registered, enable_auto_registration, rhsm_register, rhsm_unregister in utils_lib.py.
2. Update test_update.py and test_rhel_cert.py to use the rhsm register functions.