### PR TITLE
unify user-data get_console_log and update cases

### DIFF
--- a/os_tests/libs/resources_aws.py
+++ b/os_tests/libs/resources_aws.py
@@ -76,7 +76,7 @@ class EC2VM(VMResource):
         self.is_created = False
         self.another_ip = None
         self.run_uuid = params.get('run_uuid')
-        self.user_data = '#!/bin/bash\nmkdir -p /tmp/userdata_{}'.format(self.run_uuid)
+        self.user_data = None
         self.hibernation_support = False
         self.enclave_support = False
         self.enclave_enabled = False
@@ -493,22 +493,21 @@ class EC2VM(VMResource):
                 return True
         return False
 
-    def get_console_log(self, silient=False):
+    def get_console_log(self, silent=False):
         ret = None
         try:
             LOG.info("try to retrive console log of {}".format(self.id))
             ret = self.ec2_instance.console_output(Latest=True).get('Output')
-            if not silient: LOG.info(ret)
+            if not silent: LOG.info(ret)
             return ret
         except Exception as err:
             LOG.error("Failed to get console log, try without latest option! {}".format(err))
         try:
             ret = self.ec2_instance.console_output().get('Output')
-            if not silient: LOG.info(ret)
+            if not silent: LOG.info(ret)
             return ret
         except Exception as err:
             LOG.error("Failed to get console log! %s" % err)
-            if not silient: LOG.info(err)
             return err
 
     def get_state(self):

--- a/os_tests/libs/resources_gcp.py
+++ b/os_tests/libs/resources_gcp.py
@@ -116,6 +116,7 @@ class GCPVM(VMResource):
         self.flavor = params.get('Flavor').get('name')
         self.size = params.get('Flavor').get('size')
         self.user_data = None
+        self.run_uuid = params.get('run_uuid')
 
         # VM access parameters
         self.vm_username = params['VM'].get('username')

--- a/os_tests/libs/resources_nutanix.py
+++ b/os_tests/libs/resources_nutanix.py
@@ -168,11 +168,9 @@ class PrismApi(PrismSession):
             exit(1)
         # Attach ssh keys.
         ssh_key = ''
-        ssh_pwauth = '\nchpasswd:\n  list: |\n    %s:%s\n  expire: false\nssh_pwauth: yes' % (
-            self.vm_username, self.vm_password)
+        ssh_pwauth =''
         if (ssh_pubkey):
             ssh_key = '\nssh_authorized_keys:\n- %s' % ssh_pubkey
-            ssh_pwauth = ''
         # Attach user_data.
         # Since8.9/9.3, logs_go_to_stdout_if_writing_to_console_fails,
         # prompt more graceful and will not affect service cloud-final,
@@ -182,11 +180,8 @@ class PrismApi(PrismSession):
         user_data = '#cloud-config\n'
         user_data_ssh_key = '''\
 disable_root: false
-lock_passwd: false%s%s
-runcmd:\n''' % (
-            ssh_pwauth, ssh_key)
-        user_data += user_data_ssh_key+'- mkdir /tmp/userdata_{}\n'.format(self.run_uuid)
-        user_data += '''- [ sh, -xc, "echo $(date) ': hello today!'" ]'''
+lock_passwd: false%s%s\n''' % (ssh_pwauth, ssh_key)
+        user_data += user_data_ssh_key
         if self.vm_user_data:
             user_data += self.vm_user_data
         if self.user_data != None:
@@ -693,6 +688,7 @@ class NutanixVM(VMResource):
         self.vm1_ip = ''
 
         self.prism = PrismApi(params)
+        self.run_uuid = self.prism.run_uuid
 
     @property
     def is_secure_boot(self):
@@ -1202,7 +1198,7 @@ class NutanixVM(VMResource):
         res = self.prism.get_nics(self.data.get('uuid'))
         return res
 
-    def get_console_log(self):
+    def get_console_log(self, silent=False):
         raise UnSupportedAction('No such operation in nutanix')
     
     def is_exist(self):

--- a/os_tests/libs/resources_openshift.py
+++ b/os_tests/libs/resources_openshift.py
@@ -39,6 +39,7 @@ class OpenShiftVM(VMResource):
         self.vcpus = params['Flavor'].get('cpu')
         self.memory = params['Flavor'].get('memory')
         self.user_data = None
+        self.run_uuid = params.get('run_uuid')
         self._port = None
 
         # VM access parameters

--- a/os_tests/libs/resources_openstack.py
+++ b/os_tests/libs/resources_openstack.py
@@ -3,7 +3,6 @@ from os_tests.libs import utils_lib
 import logging
 import time
 import sys
-import logging
 import base64
 try:
     import openstack
@@ -66,17 +65,7 @@ class OpenstackVM(VMResource):
         self.arch = 'x86_64'
         
         # VM creation parameter user_data
-        self.user_data = """\
-#cloud-config
-
-runcmd:
-  - [ sh, -xc, "echo $(date) ': hello today!'" ]
-  - [ sh, -xc, "mkdir /tmp/userdata_{0}" ]
-
-password: {1}
-chpasswd: {{ expire: False }}
-ssh_pwauth: False
-""".format(self.run_uuid, 'R')
+        self.user_data = None
     
         # VM creation parameter for rhsm subscription related cases
         self.subscription_username = params['Subscription'].get('username')
@@ -246,14 +235,17 @@ ssh_pwauth: False
     def show(self):
         return self.data
 
-    def get_console_log(self):
+    def get_console_log(self, silent=False):
+        ret =None
         try:
-            output = self.conn.compute.get_server_console_output(
+            LOG.info("try to retrive console log of {}".format(self.data.id))
+            ret = self.conn.compute.get_server_console_output(
                 self.data.id).get('output')
-            return True, output
+            if not silent: LOG.info(ret)
+            return ret
         except Exception as err:
             LOG.error("Failed to get console log! %s" % err)
-            return False, err
+            return err
 
     @property
     def disk_count(self):

--- a/os_tests/libs/utils_lib.py
+++ b/os_tests/libs/utils_lib.py
@@ -362,6 +362,17 @@ def init_case(test_instance):
     test_instance.default_boot_index = None
     test_instance.skipflag = False
     if test_instance.vm:
+        test_instance.vm.user_data = """\
+#cloud-config
+runcmd:
+  - [ sh, -xc, "echo $(date) ': hello today!'" ]
+  - [ sh, -xc, "mkdir /tmp/userdata_{0}" ]
+
+password: {1}
+chpasswd:
+  expire: False
+ssh_pwauth: False
+""".format(test_instance.vm.run_uuid, 'R')
         if test_instance.vm.dead_count > 4:
             test_instance.fail("cannot connect to vm over 4 times, skip retry")
         if test_instance.vm.is_metal:


### PR DESCRIPTION
Unified setting user-data and get_console_log
- user-data for alicloud, nutanix, aws and openstack
- get_console_log for alicloud,nutanix,aws,openstack and libvirt
- import secrets (python>=3.6) to create random password
- updated resources_libvirt to support creating rhel vm on fedora

Updated cases
- test_cloudinit_login_with_password_userdata
- test_cloudinit_check_random_password_len
- test_cloudinit_check_runcmd
- test_cloudinit_support_nm_keyfile

Removed case
- test_cloudinit_login_with_password