### PR TITLE
Support Azure in test_check_virtwhat

### DIFF
--- a/os_tests/tests/test_general_check.py
+++ b/os_tests/tests/test_general_check.py
@@ -1808,6 +1808,9 @@ current_device"
                 self.assertIn('xen-hvm', virt_what_output)
             else:
                 self.assertIn('xen-domU', virt_what_output)
+        elif utils_lib.is_azure(self):
+            self.log.info("Found it is a Azure system!")
+            self.assertIn('hyperv', virt_what_output)
         elif 'Microsoft' in lscpu_output and not utils_lib.is_metal(self):
             self.log.info("Found it is a Hyper-V system!")
             self.assertIn('hyperv', virt_what_output)


### PR DESCRIPTION
In Azure ARM VM the CPU is not Microsoft:
```
Vendor ID:                ARM
  BIOS Vendor ID:         Ampere(R)
  Model name:             Neoverse-N1
    BIOS Model name:      Ampere(R) Altra(R) Processor
```
So use is_azure() to detect the Azure platform.