### PR TITLE
Enhance case test_create_bootc_disk_image and fix a save_file issue

### DIFF
--- a/os_tests/libs/utils_lib.py
+++ b/os_tests/libs/utils_lib.py
@@ -2121,7 +2121,7 @@ sslverify=0
 
 def save_file(test_instance, file_dir=None, file_name=None, rmt_node=None, vm=None):
     saved_file = '{}/{}'.format(file_dir, file_name)
-    if test_instance.params['remote_nodes'] is not None:
+    if test_instance.params['remote_nodes']:
         cmd = "sudo cp -f {} /tmp/".format(saved_file)
         run_cmd(test_instance, cmd, msg='Prepare for saving {}'.format(saved_file))
         test_instance.SSH.get_file(rmt_file='/tmp/{}'.format(file_name),


### PR DESCRIPTION
1. Fix save_file running in local failed issue.
2. Update container tool packages.
3. Update workspace name and disk image, adding more information.
4. Move dnf.repo from /etc/yum.repos.d/
5. Get bootc image builder when parameter bootc_image_builder isn't specified for non-rhel boot image.