### PR TITLE
Enhance the functions of test case test_create_bootc_disk_image

### DIFF
--- a/os_tests/libs/utils_lib.py
+++ b/os_tests/libs/utils_lib.py
@@ -109,10 +109,10 @@ def init_args():
                     help='specify the bootc-image-builder used for coverting custom container image to bootable disk image', required=False)
     parser.add_argument('--aws_info', dest='aws_info', default=None, action='store',
                     help='specify the aws configure information, e.g., AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,aws-region,aws-bucket', required=False)
-    parser.add_argument('--upload_image', dest='upload_image', default=None, action='store',
+    parser.add_argument('--no_upload_image', dest='no_upload_image', action='store_true',
                     help='The created bootable bootc image/disk will be saved to attachments in log, \
                         if you would like to copy the disk file to your test environment by manual, \
-                        please specify --upload_image no', required=False)
+                        please specify --no_upload_image', required=False)
     args = parser.parse_args()
     return args
 


### PR DESCRIPTION
1. Update parameter upload_image to no_upload_image for consistent.
2. Set default None value for parameters in case setup.
3. Fix issue in digest comparation.
4. Fix aws configuration path issue.
5. Fix config_toml_info key issue.
6. Move copying output files from case to tear down.