### PR TITLE
Adding resources_kvm to support KVM test

### DIFF
--- a/os_tests/cfg/kvm.yaml
+++ b/os_tests/cfg/kvm.yaml
@@ -1,0 +1,28 @@
+# This is a template for KVM resources provision for cloud-init test. 
+# Please copy it to other place that you want to edit
+# Not recommend you edit it directly in case leaking sensitive information.
+Cloud:
+  provider: kvm
+Subscription:
+  username:
+  password:
+VM:
+  os_variant: rhel-unknown
+  rhel_ver: '9.6'
+  username: cloud-user
+  password: 
+  vm_name: rhel9.6
+  image_name: 
+  #image_dir is used to store the images for cloud-init test on KVM
+  image_dir: /var/lib/libvirt/images/backup
+  #disk_path is used to store the KVM instance disk, /var/lib/libvirt/images is recommended, or it may cause the permission issue.
+  disk_path: /var/lib/libvirt/images
+  nocloud_iso_name: nocloud.iso
+  interface_name:
+  net_name:
+Flavor:
+  name: small
+  cpu: 1
+  memory: 2
+  size: 10G
+  virt: kvm

--- a/os_tests/data/kvm/br-mgmt.xml
+++ b/os_tests/data/kvm/br-mgmt.xml
@@ -1,0 +1,11 @@
+<network>
+  <name>br-mgmt</name>
+  <forward mode='open'/>
+  <bridge name='br-mgmt' stp='on' delay='0'/>
+  <ip
+    family='ipv6'
+    address='fc00:1:2::1'
+    prefix='64'
+  />
+  <dns enable='no'/>
+</network>

--- a/os_tests/data/kvm/br-prov.xml
+++ b/os_tests/data/kvm/br-prov.xml
@@ -1,0 +1,11 @@
+<network>
+  <name>br-prov</name>
+  <forward mode='open'/>
+  <bridge name='br-prov' stp='on' delay='0'/>
+  <ip
+    family='ipv6'
+    address='fc00:1:1::1'
+    prefix='64'
+  />
+  <dns enable='no'/>
+</network>

--- a/os_tests/data/kvm/br1.xml
+++ b/os_tests/data/kvm/br1.xml
@@ -1,0 +1,10 @@
+<network>
+  <name>br1</name>
+  <bridge name='virbr1'/>
+  <forward/>
+  <ip address='10.0.2.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='10.0.2.2' end='10.0.2.254'/>
+    </dhcp>
+  </ip>
+</network>

--- a/os_tests/libs/resources_kvm.py
+++ b/os_tests/libs/resources_kvm.py
@@ -1,0 +1,289 @@
+"""
+This module is used for converting linux 'virt-install' and 'virsh' command to python function
+Please install virt-install and virsh firstly.
+"""
+import logging
+import os
+import psutil
+import os_tests
+from .resources import BaseResource, VMResource
+from os_tests.libs import utils_lib
+from os_tests.libs.utils_lib import run_cmd_local,get_properties
+
+
+LOG = logging.getLogger('os_tests.os_tests_run')
+logging.basicConfig(level=logging.INFO)
+
+class KvmVM(VMResource):
+    def __init__(self, params, **kwargs):
+        super(KvmVM, self).__init__(params)
+        self.vm_name = params['VM'].get('vm_name')
+        self.image_name = params['VM'].get('image_name')
+        self.image_dir = params['VM'].get('image_dir')
+        self.disk_path = params['VM'].get('disk_path')
+        self.os_variant = params['VM'].get('os_variant')
+        self.nocloud_iso_name = params['VM'].get('nocloud_iso_name')
+        self.files_path = "./configs"
+        #create directory
+        os.makedirs(self.files_path, exist_ok=True)
+        self.isofile = "{}/{}".format(self.disk_path, self.nocloud_iso_name)
+        self.console_log = "/tmp/console_{}.log".format(self.vm_name)
+
+        self.run_uuid = params.get('run_uuid')
+        # VM access parameters
+        self.rhel_ver = params['VM'].get('rhel_ver')
+        self.vm_username = params['VM'].get('username')
+        self.vm_password = params['VM'].get('password')
+        self.ssh_pubkey = utils_lib.get_public_key()
+        self.interface_name = params['VM'].get('interface_name')
+        self.properties = {}
+        self.httpport = 8000
+
+        # VM creation parameter user_data
+        self.user_data = None
+
+
+    @property
+    @utils_lib.wait_for(not_ret='', ck_not_ret=True, timeout=120, interval=10)
+    def floating_ip(self):
+        f_ip = ''
+        cmd = "sudo virsh domifaddr {} --source arp | awk '{{print $4}}' | sed -n '3p' ".format(self.vm_name)
+        try:
+            status, out = run_cmd_local(cmd, is_log_ret=True)
+        except Exception as err:
+            LOG.info(err)
+        if len(out) > 1 and status == 0:
+            f_ip = out.split("/")[0]
+            LOG.info("ip is %s" % f_ip)
+        return f_ip
+
+    def create(self, wait=True, userdata=None, sshkey=None, datasource=None, networks=["virbr1"]):
+        # the CI job would save rhel guest image to /var/lib/libvirt/images/backup
+        # copy the image from /var/lib/libvirt/images/backup to /var/lib/libvirt/images
+        cmd1 = "sudo cp {0}/{1} {2}/{1}".format(self.image_dir, self.image_name, self.disk_path)
+        run_cmd_local(cmd1, is_log_ret=True)
+        cmd2 = "sudo virt-install --name {} --disk {}/{},device=disk,bus=virtio,format=qcow2 " \
+            "--os-variant {} "\
+            "--console log.file={} "\
+            .format(self.vm_name, self.disk_path, self.image_name, self.os_variant, self.console_log)
+
+        #networks, for example ["virbr1"] or ["br-mgmt","br-prov"]
+        if networks is not None:
+            for network in networks:
+                cmd2 += "--network bridge={},model=virtio ".format(network)
+        #userdata, using this way to compatible with other cloud platform
+        #--cloud-init and cdrom can not set at the same time, now it supports user-data, meta-data, network-config and clouduser-ssh-key and so on.'
+        userdata = userdata or self.user_data
+        if userdata:
+            userdatafilename = self.files_path+"/user-data"
+            with open(userdatafilename, 'w') as userdatafile:
+                userdatafile.write(userdata)
+            cmd2 += "--cloud-init user-data={} ".format(userdatafilename)
+
+        #--cloud-init user-data and clouduser-ssh-key can not use at the same time     
+
+        if datasource == "cdrom":
+            cmd2 += "--disk path={}/{},device=cdrom ".format(self.disk_path,self.nocloud_iso_name)
+        elif datasource == "smbios":
+            cmd2 += "--sysinfo system.serial='ds=nocloud;s=http://10.0.2.1:8000/' "
+
+        cmd2 += "--graphics none  --import --noautoconsole"
+        run_cmd_local(cmd2, timeout=360, is_log_ret=True)
+        self.floating_ip
+
+        return self.exists()
+
+    def delete(self, wait=True):
+        cmd1 = "sudo virsh destroy {}".format(self.vm_name)
+        run_cmd_local(cmd1, is_log_ret=True)
+        cmd2 = "sudo virsh undefine {}".format(self.vm_name)
+        run_cmd_local(cmd2, is_log_ret=True)
+        if wait:
+            error_message = "Timed out waiting for server to get deleted."
+            for count in utils_lib.iterate_timeout(100, error_message, wait=10):
+                if not self.exists():
+                    break
+        # remove the image
+        cmd3 = "sudo rm {}/{}".format(self.disk_path, self.image_name)
+        run_cmd_local(cmd3, is_log_ret=True)
+
+        #do we need remove data file here?
+        self.delete_datafile()
+
+    def exists(self):
+        cmd = "sudo virsh dominfo {} ".format(self.vm_name)
+        try:
+            status, out = run_cmd_local(cmd, is_log_ret=True)
+            if len(out)>1 and status == 0:
+                self.properties = get_properties(out)
+                return True
+        except Exception as err:
+            LOG.info(err)
+            return False
+        return False
+
+    def show(self):
+        if self.exists():
+            LOG.info("Instance ID: {}".format(self.properties.get("UUID")))
+        else:
+            LOG.info("the vm instance does not exist")
+
+    def start(self, wait=False):
+        cmd = "sudo virsh start {}".format(self.vm_name)
+        run_cmd_local(cmd, is_log_ret=True)
+
+    def stop(self, wait=False):
+        cmd = "sudo virsh shutdown {}".format(self.vm_name)
+        run_cmd_local(cmd, is_log_ret=True)
+
+    def reboot(self, wait=False):
+        raise NotImplementedError
+
+    def pause(self, wait=False):
+        raise NotImplementedError
+
+    def unpause(self, wait=False):
+        raise NotImplementedError
+
+    def get_state(self):
+        if self.exists():
+            return self.properties.get("State")
+
+    def is_started(self):
+        if self.exists():
+            return self.get_state() == "running"
+
+    def is_stopped(self):
+        if self.exists():
+            return self.get_state() == "shut off"
+
+    def is_paused(self):
+        return self.get_state() == "paused"
+
+    def get_console_log(self, silent=False):
+        out = None
+        cmd = "sudo cat {}".format(self.console_log)
+        try:
+            _, out = run_cmd_local(cmd, is_log_ret=True)
+        except Exception as err:
+            LOG.info(err)
+        return out
+
+    def disk_count(self):
+        raise NotImplementedError
+
+    def send_nmi(self):
+        raise NotImplementedError
+
+    def send_hibernation(self):
+        raise NotImplementedError
+
+    def attach_block(self, disk, target, wait=True, timeout=120):
+        raise NotImplementedError
+
+    def detach_block(self, disk, wait=True, force=False):
+        raise NotImplementedError
+
+    def attach_nic(self, nic, wait=True, timeout=120):
+        raise NotImplementedError
+
+    def detach_nic(self, nic, wait=True, force=False):
+        raise NotImplementedError
+
+    def is_exist(self):
+        return self.exists()
+
+    def create_datafile(self, datasource, userdata, metadata, networkconfig=None):
+        #create data file, userdata and metadata can not be None
+        userdatafilename = self.files_path+"/user-data"
+        with open(userdatafilename, 'w') as userdatafile:
+            userdatafile.write(userdata)
+        metadatafilename = self.files_path+"/meta-data"
+        with open(metadatafilename, 'w') as metadatafile:
+            metadatafile.write(metadata)
+        networkfilename = self.files_path+"/network-config"
+        if networkconfig is not None:
+            with open(networkfilename, 'w') as networkconfigfile:
+                networkconfigfile.write(networkconfig)
+        else:
+            #clean the data or it would effect other case, for example network-config would be added to the case without network-config
+            if os.path.exists(networkfilename):
+                os.remove(networkfilename)
+            networkfilename = ""
+        if datasource == "cdrom":
+            #create iso file in /var/lib/libvirt/images/
+            cmd = "sudo genisoimage -output {} -volid CIDATA -joliet -rock  {} {} {}".format(self.isofile, userdatafilename, metadatafilename, networkfilename)
+            run_cmd_local(cmd,is_log_ret=True)
+        elif datasource == "smbios":
+            # check if the http server is not started, start it
+            if not self.is_httpserver_running():
+                cmd = "nohup python3 -m http.server {} --directory {} > httpserver.log 2>&1 &".format(self.httpport,self.files_path)
+                run_cmd_local(cmd,is_log_ret=True)
+        return True
+    
+    def delete_datafile(self):
+        cmd = "sudo rm {}".format(self.isofile)
+        run_cmd_local(cmd,is_log_ret=True)
+        cmd = "rm {}/*".format(self.files_path)
+        run_cmd_local(cmd,is_log_ret=True)
+        return True
+
+    def is_httpserver_running(self):
+        """Check if a process is using the given port."""
+        for conn in psutil.net_connections():
+            if conn.laddr.port == self.httpport:
+                return True
+        return False
+
+
+class KvmNet(BaseResource):
+    def __init__(self, params, **kwargs):
+        super(KvmNet, self).__init__(params)
+        self.netname = kwargs.get("netname") if "netname" in kwargs else params.get('VM').get("net_name")
+        self.netfile = os.path.dirname(os_tests.__file__) + "/data/kvm/{}.xml".format(self.netname)
+        self.properties = {}
+
+    def create(self):
+        # cannot start network without root user
+        cmd1 = "sudo virsh net-define {}".format(self.netfile)
+        run_cmd_local(cmd1,is_log_ret=True)
+        cmd2 = "sudo virsh net-start {}".format(self.netname)
+        run_cmd_local(cmd2,is_log_ret=True)
+        return True
+
+    def delete(self):
+        cmd1 = "sudo virsh net-destroy {}".format(self.netname)
+        run_cmd_local(cmd1,is_log_ret=True)
+        cmd2 = "sudo virsh net-undefine {}".format(self.netname)
+        run_cmd_local(cmd2,is_log_ret=True)
+        return True
+
+    def start(self):
+        cmd = "sudo virsh net-start {}".format(self.netname)
+        run_cmd_local(cmd,is_log_ret=True)
+        return True
+
+    def get_state(self):
+        if self.exists():
+            return self.properties.get("Active")
+
+    def exists(self):
+        cmd = "sudo virsh net-info {} ".format(self.netname)
+        try:
+            status, out = run_cmd_local(cmd, is_log_ret=True)
+            if len(out)>1 and status == 0:
+                self.properties = get_properties(out)
+                return True
+        except Exception as err:
+            LOG.info(err)
+            return False
+        return False
+
+    def is_exist(self):
+        return self.exists()
+
+    def show(self):
+        if self.exists():
+            LOG.info("network id : {}".format(self.properties.get("UUID")))
+        else:
+            LOG.info("the network does not exist")

--- a/os_tests/os_tests_run.py
+++ b/os_tests/os_tests_run.py
@@ -28,14 +28,14 @@ def main():
     if args.params_profile:
         tmp_params = get_cfg(cfg_file=args.params_profile)
         update_cfgs(params, tmp_params)
-    vms, disks, nics, sshs = [], [], [], []
+    vms, disks, nics, sshs, nets = [], [], [], [], []
     if params.get('Cloud') or args.platform_profile:
         if args.platform_profile:
             provider_data = get_cfg(cfg_file=args.platform_profile)
             update_cfgs(params, provider_data)
         update_cfgs(params, vars(args))
         if not args.is_listcase and not args.verifydoc and not args.dumpdoc:
-            vms, disks, nics = init_provider(params=params)
+            vms, disks, nics, nets = init_provider(params=params)
     update_cfgs(params, vars(args))
 
     if args.remote_nodes:
@@ -96,6 +96,7 @@ def main():
                         case.disk = case.disks and disks[0] or None
                         case.nics = nics
                         case.nic = case.nics and nics[0] or None
+                        case.createvm = True
                         if filter_case_doc(case=case, patterns=test_patterns, skip_patterns=skip_patterns,
                                            filter_field=params.get('filter_by'), strict=params.get('is_strict'), verify_doc=params.get('verifydoc')):
                             tests_list.append(case)
@@ -139,10 +140,10 @@ def main():
     else:
         HTMLTestRunner(verbosity=2).run(final_ts)
 
-    for res in chain(vms, disks, nics):
+    for res in chain(vms, disks, nics, nets):
         if params.get('no_cleanup'):
             log.info("skipped resource cleanup because --no-cleanup found, please release resources manually")
-            for i in chain(vms, disks, nics):
+            for i in chain(vms, disks, nics, nets):
                 if i.id:
                     log.info(i.id)
             break

--- a/os_tests/tests/test_cloud_init_newvm.py
+++ b/os_tests/tests/test_cloud_init_newvm.py
@@ -1,0 +1,323 @@
+import unittest
+import os
+import secrets
+import time
+from os_tests.libs import utils_lib
+from os_tests.libs import version_util
+from os_tests.libs.resources import UnSupportedAction
+from parameterized import parameterized
+
+#this class is the collection of cases that require new vm
+class TestCloudInitNewVM(unittest.TestCase):
+    def setUp(self):
+        #do not create vm in init_case, because it will create new vm in test case
+        self.createvm = False
+        utils_lib.init_case(self)
+
+    @property
+    def rhel_x_version(self):
+        return int(self.vm.rhel_ver.split('.')[0])
+
+    #the datasource of cloud-init for cdrom and smbios are different, using parameterized to expand the test case
+    @parameterized.expand(["cdrom","smbios"])
+    def test_cloudinit_staticip_dns_metric(self, datasource):
+        """
+        case_tag:
+            cloudinit,cloudinit_tier2,vm_delete
+        case_name:
+            test_cloudinit_staticip_dns_metric
+        case_file:
+            test_cloud_init_newvm.py
+        component:
+            cloud-init
+        bugzilla_id:
+            RHEL-81896,RHEL-81703,RHEL-44334,RHEL-59980,RHEL-65016,RHEL-61224
+        is_customer_case:
+            True
+        testplan:
+            N/A
+        maintainer:
+            xiachen@redhat.com
+        description:
+            Check cloud-init can configure static IP, nameservers and metric
+        key_steps:
+            1.#prepare user-data,meta-data and network-data
+            2.#launch a KVM instance
+            3.#login and check IP,nameservers and metric
+        expect_result:
+            ip is the static IP
+            nameservers configured in /etc/resolv.conf
+            metric value is same as network-config
+        debug_want:
+            cloud-init
+        """
+        #When @unittest.skipUnless is placed before @parameterized.expand, it does not work as expected. 
+        #This happens because @parameterized.expand modifies the test method before @unittest.skipUnless applies, 
+        #so skipping does not apply to the expanded test cases
+        #solution: skipping inside the test method
+        if os.getenv('INFRA_PROVIDER') != 'kvm':
+            self.skipTest('skip test as it is the specific test case for kvm.')
+
+        # create vm and then do test
+        interface_name = self.vm.interface_name or "eth0"  # for rhel 10, interface name is enp1s0
+        if self.rhel_x_version >= 10:
+            interface_name = self.vm.interface_name or "enp1s0"
+
+        user_data = """\
+#cloud-config
+user: {}
+password: {}
+chpasswd:
+  expire: False
+ssh_authorized_keys:
+ - "{}"
+""".format(self.vm.vm_username, self.vm.vm_password, self.vm.ssh_pubkey)
+
+        meta_data ="""\
+"""
+        network_config ="""\
+#cloud-config
+network:
+  config:
+    - name: {0}
+      subnets:
+        - address: 10.0.2.2/24
+          gateway: 10.0.2.1
+          type: static
+          routes:
+            - destination: 0.0.0.0/0
+              gateway: 10.0.2.1
+              metric: 99
+            - destination: 192.168.122.1/24
+              gateway: 10.0.2.1
+              metric: 98
+            - destination: 10.0.1.1/24
+              gateway: 10.0.2.1
+      type: physical
+    - type: nameserver
+      interface: {0}
+      address:
+        - 8.8.8.8
+        - 4.4.4.4
+      search:
+        - example.com
+  version: 1
+""".format(interface_name)
+
+        #remove vm if it exists
+        if self.vm.exists():
+            self.vm.delete()
+
+        #create iso or start http server
+        self.vm.create_datafile(datasource=datasource,userdata=user_data,metadata=meta_data,networkconfig=network_config) 
+        #create vm
+        self.vm.create(datasource=datasource)
+        time.sleep(60)
+        #login and check
+        self.ssh_timeout = 30
+        utils_lib.init_connection(self, timeout=self.ssh_timeout)
+
+        # cloud-init 24.3+ support network-config with smbios, but it has a bug, RHEL-81896,RHEL-81703
+        package_ver = utils_lib.run_cmd(self, "rpm -q cloud-init").rstrip('\n')
+        version = version_util.get_version(package_ver,'cloud-init-')
+        if datasource == "smbios":
+            support_cases = self.vm.support_cases
+            main_support_versions = ["24.4-5.el9","24.4-4.el10"]
+            backport_versions = None
+            if not version_util.is_support(version,"test_cloudinit_staticip_dns_metric",support_cases,main_support_versions,backport_versions):
+                self.skipTest("Skip test_cloudinit_staticip_dns_metric_smbios because it does not support network-config for "+package_ver)
+
+        failures = []
+        #step1 checking IP configuration
+        ipkeywords = ["10.0.2.2/24"]
+        step = "check IP configuration is "+ str(ipkeywords)
+        cmd = "ip a s"
+        failures += utils_lib.check_cmd_output(self,step,cmd,keywords=ipkeywords)
+
+        if datasource == "cdrom":
+            support_cases = self.vm.support_cases
+            #the max version of step2 and step3
+            main_support_versions = ["24.4-1.el9","24.1.4-21.el10"]
+            backport_versions = ["23.4-7.el9_4.11","23.4-19.el9_5.4"]
+            if not version_util.is_support(version,"test_cloudinit_staticip_dns_metric",support_cases,main_support_versions,backport_versions):
+                self.skipTest("Skip test_cloudinit_staticip_dns_metric_cdrom because it does not support dns and metric configuration for "+package_ver)
+
+        #step2 checking dns configuration
+        #nameserver 24.1 for rhel 10(RHEL-44334), and 24.4 rebase for rhel9.6 (RHEL-59980)
+        #cloud-init config dns cloud-init-24.1.4-21.el10(RHEL-65769), cloud-init-23.4-22.el9(RHEL-657680)
+        #backport cloud-init-23.4-19.el9_5.4(RHEL-65778,RHEL-68409), cloud-init-23.4-7.el9_4.11(RHEL-65777,RHEL-68408)
+        dnskeywords = ["nameserver 8.8.8.8","nameserver 4.4.4.4","search example.com"]
+        step = "check dns configuration contains "+ str(dnskeywords)
+        cmd = "cat /etc/resolv.conf"
+        failures += utils_lib.check_cmd_output(self,step,cmd,keywords=dnskeywords)
+
+        #step3 checking metric configuration
+        #cloud-init-24.1.4-19.el10(RHEL-65016), cloud-init-23.4-20.el9(RHEL-61224)
+        #backport cloud-init-23.4-19.el9_5.1(RHEL-65018), cloud-init-23.4-7.el9_4.8(RHEL-65017)
+        checks = [("default","metric 99"),
+                  ("to 10.0.1.0/24","metric 99"),
+                  ("to 10.0.2.0/24","metric 99"),
+                  ("to 192.168.122.0/24","metric 98")]
+        for destination,metricvalue in checks:
+            step = "check {} metric value is {}".format(destination,metricvalue)
+            metrickeywords = [metricvalue]
+            cmd = "ip route show {}".format(destination)
+            failures += utils_lib.check_cmd_output(self,step,cmd,keywords=metrickeywords)
+
+        if failures:
+            self.fail("\n"+"\n".join(failures))
+
+    @parameterized.expand(["cdrom","smbios"])
+    def test_cloudinit_userdata_metadata(self, datasource):
+        """
+        case_tag:
+            cloudinit,cloudinit_tier2,vm_delete
+        case_name:
+            test_cloudinit_userdata_metadata
+        case_file:
+            test_cloud_init_newvm.py
+        component:
+            cloud-init
+        bugzilla_id:
+            RHEL-66128
+        is_customer_case:
+            True
+        testplan:
+            N/A
+        maintainer:
+            xiachen@redhat.com
+        description:
+            the basic check for cloud-init on KVM
+        key_steps:
+            1.#prepare user-data and meta-data
+            2.#launch a KVM instance
+            3.#login to check the configuration, e.g. hostname, datasource, cloud-init status
+        expect_result:
+            ssh login is success
+            hostname is configured
+            datasource is recognized correctly
+        debug_want:
+            cloud-init
+        """
+        #When @unittest.skipUnless is placed before @parameterized.expand, it does not work as expected. 
+        #solution: skipping inside the test method
+        if os.getenv('INFRA_PROVIDER') != 'kvm':
+            self.skipTest('skip test as it is the specific test case for kvm.')
+
+        user_data = """\
+#cloud-config
+user: {}
+password: {}
+chpasswd:
+  expire: False
+ssh_authorized_keys:
+ - "{}"
+""".format(self.vm.vm_username, self.vm.vm_password, self.vm.ssh_pubkey)
+ 
+        meta_data ="""\
+instance-id: example
+local-hostname: myhost
+"""
+
+        #remove vm if it exists
+        if self.vm.exists():
+            self.vm.delete()
+
+        #create iso or start http server
+        self.vm.create_datafile(datasource=datasource,userdata=user_data,metadata=meta_data)  
+        #create vm
+        self.vm.create(datasource=datasource)
+        time.sleep(60)
+
+        #login and check, successfully login means ssh key is configured well
+        self.ssh_timeout = 30
+        utils_lib.init_connection(self, timeout=self.ssh_timeout)
+
+        # cloud-init 24.1 started to support smbios
+        if datasource == "smbios":
+            support_cases = self.vm.support_cases
+            main_support_versions = ["24.4-1.el9","24.1.4.el10"] # RHEL-66128 for rhel9.6
+            backport_versions = ["23.4-7.el9_4.12","23.4-19.el9_5.5"] # RHEL-79773, RHEL-79774
+            package_ver = utils_lib.run_cmd(self, "rpm -q cloud-init").rstrip('\n')
+            version = version_util.get_version(package_ver,'cloud-init-')
+            if not version_util.is_support(version,"test_cloudinit_userdata_metadata",support_cases,main_support_versions,backport_versions):
+                self.skipTest("Skip test_cloudinit_staticip_dns_metric_smbios because it does not support network-config for "+package_ver)
+
+        failures = []
+        #check host name is myhost
+        hostnamekws = ["myhost"]
+        step = "check hostname configuration is "+ str(hostnamekws)
+        cmd = "hostname"
+        failures += utils_lib.check_cmd_output(self,step,cmd,keywords=hostnamekws)
+
+        #check datasource
+        if datasource == "smbios":
+            datasourcekws = ["DataSourceNoCloudNet"]
+        elif datasource == "cdrom":
+            datasourcekws = ["DataSourceNoCloud [seed=/dev/sr0]"]
+        step ="check datasource is "+ str(datasourcekws)
+        cmd = "cat /var/lib/cloud/instance/datasource"
+        failures += utils_lib.check_cmd_output(self,step,cmd,keywords=datasourcekws)
+
+        #check cloud-init status
+        if failures:
+            self.fail("\n"+"\n".join(failures))
+
+    #moved the test method which require new VM into this test class
+    @unittest.skipIf(os.getenv('INFRA_PROVIDER') == 'libvirt', 'skip run as this needs to configure user-data')
+    def test_cloudinit_login_with_password_userdata(self):
+        """
+        case_tag:
+            cloudinit,cloudinit_tier1,vm_delete
+        case_priority:
+            1
+        component:
+            cloud-init
+        maintainer:
+            huzhao@redhat.com
+        description: |
+            RHEL7-103830 - CLOUDINIT-TC: VM can successfully login
+            after provisioning(with password authentication)
+        key_steps: |
+            1. Create a VM with only password authentication
+            2. Login with password, should have sudo privilege
+        """
+        password_length = 10
+        vm_password = secrets.token_urlsafe(password_length)
+        vm_username = "test-user"
+        self.log.info(vm_username)
+        self.log.info(vm_password)
+        if self.vm.exists():
+            self.vm.delete()
+            time.sleep(30)
+        user_data = """\
+#cloud-config
+
+user: {0}
+password: {1}
+chpasswd: {{ expire: False }}
+ssh_pwauth: True
+""".format(vm_username, vm_password)
+        self.vm.create(userdata=user_data,sshkey="DoNotSet")
+        if self.vm.is_stopped():
+            self.vm.start(wait=True)
+        time.sleep(30)
+        self.params['remote_node'] = self.vm.floating_ip
+        test_login = utils_lib.send_ssh_cmd(self.vm.floating_ip, vm_username, vm_password, "whoami", log=self.log)
+        self.assertEqual(vm_username,
+                         test_login[1].strip(),
+                         "Fail to login with password: %s" % format(test_login[1].strip()))
+        test_sudo = utils_lib.send_ssh_cmd(self.vm.floating_ip, vm_username, vm_password, "sudo cat /etc/sudoers.d/90-cloud-init-users", log=self.log)
+        self.assertIn("%s ALL=(ALL) NOPASSWD:ALL" % vm_username,
+                         test_sudo[1].strip(),
+                         "No sudo privilege")
+
+
+    def tearDown(self):
+        utils_lib.finish_case(self)
+        #remove the vm in teardown as it is specific and may can not be connected by other cases
+        if not self.params.get('no_cleanup') and self.vm.exists():
+            self.vm.delete(wait=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,14 @@ setuptools.setup(
         'os_tests': [
             'cfg/*',
             'docs/*',
-            'data/*',
+            'data/**/*',
             'templates/*',
             'utils/*'
         ]
     },
     include_package_data=True,
     #data_files=[('/'+os.path.expanduser("~"), ['cfg/os-tests.yaml']),],
-    install_requires=['PyYAML', 'Jinja2<=2.11.3', 'tipset>=0.2.4', 'markupsafe<=1.1.1', 'packaging<=21.3'],
+    install_requires=['PyYAML', 'Jinja2<=2.11.3', 'tipset>=0.2.4', 'markupsafe<=1.1.1', 'packaging<=21.3', 'psutil', 'parameterized'],
     license="GPLv3+",
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',


### PR DESCRIPTION
1. resources_kvm
   - using virt-install to create vm, it supports configure data from cdrom and smbios.
   - supports creating networks for KVM test
2. added a test class test_cloud_init_newvm, it will include all cases that require new VM
3. added two KVM specific test cases (parameterized to expand 2 to 4 cases)
4. moved one exist case test_cloudinit_login_with_password_userdata to test_cloud_init_newvm (will move others in future)
5. added check_cmd_output to utils_lib, the test wouldn't be stopped if one step/command fails, it collects all failures.