### PR TITLE
[Azure]Support disk_controller_type

### DIFF
--- a/os_tests/cfg/azure.yaml
+++ b/os_tests/cfg/azure.yaml
@@ -30,5 +30,7 @@ VM:
     sriov: 'false'
     net_bandwidth: 10000
     cvm: 'false'
+    # For Mdsv3-series can use disk_controller_type to specify SCSI/NVME disk type
+    disk_controller_type:
 Other:
     packages: <the cloud-init package name: cloud-init-xxx.rpm>

--- a/os_tests/libs/resources_azure.py
+++ b/os_tests/libs/resources_azure.py
@@ -79,6 +79,7 @@ class AzureVM(VMResource):
         self.custom_data = params.get('VM').get("custom_data")
         self.net_bandwidth_cfg = params.get('VM').get('net_bandwidth')
         self.cvm = params['VM'].get('cvm', 'false').lower()
+        self.disk_controller_type = params['VM'].get('disk_controller_type')
         self.sriov = params.get('VM').get('sriov', 'false').lower()
         self.user_data = None
         self.user_data_file = None
@@ -166,6 +167,8 @@ class AzureVM(VMResource):
             cmd += ' --security-type ConfidentialVM --enable-secure-boot true --enable-vtpm true --os-disk-security-encryption-type VMGuestStateOnly'
         if self.os_disk_size:
             cmd += ' --os-disk-size-gb {}'.format(self.os_disk_size)
+        if self.disk_controller_type:
+            cmd += ' --disk-controller-type {}'.format(self.disk_controller_type)
         if not wait:
             cmd += " --no-wait"
         _, out = run_cmd_local(cmd, timeout=360, is_log_ret=True)


### PR DESCRIPTION
Can use disk_controller_type parameter to specify SCSI/NVME disk type when create VM.