### PR TITLE
using virtctl as proxy to access vm in ocp.

### DIFF
--- a/os_tests/libs/resources_openshift.py
+++ b/os_tests/libs/resources_openshift.py
@@ -77,12 +77,12 @@ class OpenShiftVM(VMResource):
                 stdout=subprocess.PIPE).communicate()[0] \
                     .decode("utf-8").rstrip('\n')
         #return self._port   
-        return 22
+        return 2222
 
     @port.setter
     def port(self, name):
         subprocess.Popen(
-            'virtctl expose vm %s --port=22 --name=%s --type=LoadBalancer' % (name, name),
+            'virtctl expose vm %s --port=22 --name=%s --type=NodePort' % (name, name),
             shell=True,
             stdout=FNULL).communicate()
     
@@ -113,7 +113,8 @@ class OpenShiftVM(VMResource):
                             with open(known_hosts_path, "a") as known_hosts:
                                 known_hosts.write(filtered_output + "\n")
                     
-                        return ext_ip
+                        #return ext_ip
+                        return self.vm_name
 
         except subprocess.CalledProcessError as e:
             print(f"Error fetching services: {e}")


### PR DESCRIPTION
According to the ITUP Admin, they can provide at most two LoadBalancer services, which is insufficient for running our jobs in parallel. Supporting multiple LoadBalancer services would require additional costs and logistical efforts on their part. Therefore, we need to change the SSH connection method from LoadBalancer to using virtctl as a proxy.

This change affects the utils_lib.py, resources_openshift.py, and test_rhel_guest_image.py files. However, the primary focus for review should be on utils_lib.py and resources_openshift.py, as the modifications in test_rhel_guest_image.py mainly handle additional output related to the proxy connection method.