### PR TITLE
Extend creating VM timeout and disable deleting the 2nd vm in tearDown

### DIFF
--- a/os_tests/libs/resources_azure.py
+++ b/os_tests/libs/resources_azure.py
@@ -168,7 +168,7 @@ class AzureVM(VMResource):
             cmd += ' --os-disk-size-gb {}'.format(self.os_disk_size)
         if not wait:
             cmd += " --no-wait"
-        _, out = run_cmd_local(cmd, timeout=360, is_log_ret=True)
+        _, out = run_cmd_local(cmd, timeout=720, is_log_ret=True)
         if len(out):
             return self.show()
 

--- a/os_tests/tests/test_rhel_cert.py
+++ b/os_tests/tests/test_rhel_cert.py
@@ -446,10 +446,10 @@ class TestRHELCert(unittest.TestCase):
         # Only ethernet and kdump over nfs require the 2nd vm.
         # Stop the 2nd vm after test done on azure for saving cost.
         # aws keeps the 2nd vm because it takes long time to restart a metal insatnce over 20mins
-        if os.getenv('INFRA_PROVIDER') == 'azure':
-            if len(self.vms) > 1:
-               if self.vms[1].exists():
-                   self.vms[1].delete()
+        #if os.getenv('INFRA_PROVIDER') == 'azure':
+        #    if len(self.vms) > 1:
+        #       if self.vms[1].exists():
+        #           self.vms[1].delete()
         utils_lib.finish_case(self)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The big size VM needs longer time to boot up.