### PR TITLE
Change double quotes of the f-string sudo cat {kar_avocado_conf} to single quoteingle quote

### DIFF
--- a/os_tests/tests/test_kar.py
+++ b/os_tests/tests/test_kar.py
@@ -112,7 +112,7 @@ class TestKAR(unittest.TestCase):
         # Then put them into os-tests resutls dir
         kar_config = configparser.ConfigParser()
         ret, out = utils_lib.run_cmd(self,
-                                     f"sudo cat {self.params.get("kar_avocado_conf")}",
+                                     f'sudo cat {self.params.get("kar_avocado_conf")}',
                                      is_log_cmd=True,
                                      ret_out=True,
                                      ret_status=True)


### PR DESCRIPTION
Fix https://github.com/virt-s1/os-tests/issues/580