### PR TITLE
Update cloud-init rhsm cases

### DIFF
--- a/os_tests/libs/resources_nutanix.py
+++ b/os_tests/libs/resources_nutanix.py
@@ -810,6 +810,7 @@ class NutanixVM(VMResource):
                 res['task_uuid'], 60,
                 "Timed out waiting for server to get created.")
         self._data = None
+        return True
         
     def create_by_ISO_kickstart(self, wait=False, single_nic=True, vm_name=None):
         logging.info("Create VM by ISO kickstart")

--- a/os_tests/libs/resources_openstack.py
+++ b/os_tests/libs/resources_openstack.py
@@ -148,6 +148,7 @@ class OpenstackVM(VMResource):
                 self.conn.compute.add_floating_ip_to_server(
                     server, f_ip.floating_ip_address)
         self._data = None
+        return True
 
     def delete(self, wait=True):
         f_ip = self.floating_ip

--- a/os_tests/tests/test_cloud_init.py
+++ b/os_tests/tests/test_cloud_init.py
@@ -2582,6 +2582,93 @@ ssh_pwauth: True '''.format(**pw_config_dict)
             res = utils_lib.run_cmd(self, "sudo systemctl status cloud-final")
             if re.search('active \(exited\)', res): break
 
+    @unittest.skipUnless(os.getenv('INFRA_PROVIDER') in ['openstack','nutanix','kvm'], 'skip run as this case need connect rhsm stage server, not suitable for public cloud')
+    def test_cloudinit_verify_rh_subscription_enablerepo_disablerepo(self):
+        """
+        case_tag:
+            cloudinit,cloudinit_tier2,vm_delete
+        case_priority:
+            2
+        component:
+            cloud-init
+        maintainer:
+            xiachen@redhat.com
+        description:
+            RHEL-189134 - CLOUDINIT-TC: Verify rh_subscription enable-repo and disable-repo
+        key_steps: |
+            1. Add content to user data config file
+            rh_subscription:
+            username: ******
+            password: ******
+            enable-repo: ['rhel-*-baseos-*rpms']
+            disable-repo: ['rhel-*-appstream-*rpms']
+            2. create VM
+            3. Verify register with subscription-manager and enabled repos and disabled repos successfully
+        """
+        rhel_ver = self.rhel_x_version
+        self.log.info("RHEL-189134 - CLOUDINIT-TC: Verify rh_subscription enable-repo and disable-repo")
+        #subscription-manager repos --enable (or --disable) does not support regular expressions or wildcards (like * or .) in the repository names
+        repokey = ""
+        if 'Beta' in utils_lib.run_cmd(self,'sudo cat /etc/redhat-release'):
+            repokey = "beta-" 
+        if self.vm.exists():
+            self.vm.delete()
+            time.sleep(30)
+        user_data = """\
+#cloud-config
+
+rh_subscription:
+  username: {0}
+  password: {1}
+  rhsm-baseurl: {2}
+  server-hostname: {3}
+  enable-repo: ['rhel-{4}-for-x86_64-baseos-{6}rpms']
+  disable-repo: ['rhel-{4}-for-x86_64-appstream-{6}rpms']
+
+ssh_authorized_keys:
+    - {5}
+""".format(self.vm.subscription_username, self.vm.subscription_password,
+    self.vm.subscription_baseurl, self.vm.subscription_serverurl, rhel_ver, utils_lib.get_public_key(), repokey)
+        status = self.vm.create(userdata=user_data)
+        if not status:
+            self.fail("Create vm failed, please check!")
+        if self.vm.is_stopped():
+            self.vm.start(wait=True)
+        time.sleep(30)
+        #check login
+        status = utils_lib.init_connection(self, timeout=self.ssh_timeout)
+        if not status:
+            self.fail("Login failed, please check!")
+
+        # waiting for subscription-manager register done.
+        # 51.55900s (modules-config/config-rh_subscription)
+        self.log.info("Waiting 60s for subscription-manager done...")
+        time.sleep(60)
+        # check cloud-init status is done and services are active
+        self._check_cloudinit_done_and_service_isactive()
+        # check register
+        cmd = "sudo grep 'Registered successfully' /var/log/cloud-init.log"
+        utils_lib.run_cmd(self,
+                    cmd,
+                    expect_ret=0,
+                    expect_kw='Registered successfully',
+                    msg='Check registered successfully log in cloud-init.log')
+        cmd = "sudo subscription-manager identity"
+        utils_lib.run_cmd(self,
+                    cmd,
+                    expect_ret=0,
+                    msg='Register with subscription-manager')
+        # SCA enabled ignoring auto-attach
+        # check enabled/disabled repos
+        enable_repo_1 = 'rhel-{}-for-x86_64-baseos-{}rpms'.format(rhel_ver, repokey)
+        disable_repo = 'rhel-{}-for-x86_64-appstream-{}rpms'.format(rhel_ver, repokey)
+        repolist = utils_lib.run_cmd(self, "yum repolist|awk '{print $1}'").split('\n')
+        self.assertIn(enable_repo_1, repolist,
+            "Repo of {} is not enabled".format(enable_repo_1))
+        self.assertNotIn(disable_repo, repolist,
+            "Repo of {} is not disabled".format(disable_repo))
+        #teardown
+
     def test_cloudinit_puppet_in_correct_stage(self):
         """
         case_tag:
@@ -3533,7 +3620,8 @@ ssh_authorized_keys:
     
     def tearDown(self):
         utils_lib.finish_case(self)
-        casegroup = ('test_cloudinit_no_networkmanager')
+        casegroup = ('test_cloudinit_no_networkmanager',
+                     'test_cloudinit_verify_rh_subscription_enablerepo_disablerepo')
         if self.id().endswith(casegroup) and not self.skipflag:
             utils_lib.run_cmd(self, "sudo subscription-manager unregister")
 
@@ -3541,6 +3629,7 @@ ssh_authorized_keys:
                      'test_cloudinit_check_previous_hostname',
                      'test_cloudinit_sshd_keypair',
                      'test_cloudinit_no_networkmanager',
+                     'test_cloudinit_verify_rh_subscription_enablerepo_disablerepo',
                      'test_cloudinit_mount_with_noexec_option',
                      'test_cloudinit_disable_cloudinit')
         if self.id().endswith(casegroup) and not self.skipflag and not self.params.get('no_cleanup'):


### PR DESCRIPTION
Modified 3 cases because of gating test failure
- test_cloudinit_login_with_password_userdata
- test_cloudinit_auto_install_package_with_subscription_manager
- test_cloudinit_verify_rh_subscription_enablerepo_disablerepo