### PR TITLE
Check ret code in subscription-manager status instead of output

### DIFF
--- a/os_tests/tests/test_general_test.py
+++ b/os_tests/tests/test_general_test.py
@@ -533,8 +533,8 @@ int main(int argc, char *argv[])
             cmd = "sudo subscription-manager list --installed"
             out = utils_lib.run_cmd(self, cmd, msg='try to list currently installed on the system')
             cmd = "sudo subscription-manager status"
-            out = utils_lib.run_cmd(self, cmd, msg='try to check subscription status')
-            if 'Red Hat Enterprise Linux' in out or 'Simple Content Access' in out:
+            status = utils_lib.run_cmd(self, cmd, msg='try to check subscription status', ret_status=True, ret_out=False)
+            if status == 0:
                 self.log.info("auto subscription registered completed")
                 cmd = "sudo insights-client --register"
                 utils_lib.run_cmd(self, cmd, msg='check if insights-client can register successfully')


### PR DESCRIPTION
Due to the patch https://github.com/candlepin/subscription-manager/pull/3504 , status output doesn't contain SCA message. So change to only verify return code 0. If VM is not registered, it'll return 1.